### PR TITLE
Simplify spread semantics.

### DIFF
--- a/dolang-private-regression/tests/regression/runtime/set/misc.dol
+++ b/dolang-private-regression/tests/regression/runtime/set/misc.dol
@@ -51,4 +51,11 @@ catch _
   true
 assert $caught
 
+let pair_set = set {1, foo: "bar"}
+assert_eq $pair_set.len 2
+let pair_items = [...pair_set]
+assert_eq $pair_items[0] 1
+assert_eq $pair_items[1][0] :foo:
+assert_eq $pair_items[1][1] "bar"
+
 assert (type (set([]).iter()) std.Iter)

--- a/dolang-private-regression/tests/regression/variadic_data.dol
+++ b/dolang-private-regression/tests/regression/variadic_data.dol
@@ -20,3 +20,21 @@ let items = [1, 2, 3].iter()
 assert_eq (array items) [1, 2, 3]
 let entries = (["foo=bar", "baz=qux"].iter().map do |e| e.split "=")
 assert_eq (dict entries) {"foo": "bar", "baz": "qux"}
+
+let arr = [...{1, foo: "bar", 2}]
+assert_eq $arr[0] 1
+assert_eq $arr[1][0] :foo:
+assert_eq $arr[1][1] "bar"
+assert_eq $arr[2] 2
+
+arr = array {1, foo: "bar", 2}
+assert_eq $arr[0] 1
+assert_eq $arr[1][0] :foo:
+assert_eq $arr[1][1] "bar"
+assert_eq $arr[2] 2
+
+let tup = tuple({1, foo: "bar", 2})
+assert_eq $tup[0] 1
+assert_eq $tup[1][0] :foo:
+assert_eq $tup[1][1] "bar"
+assert_eq $tup[2] 2

--- a/dolang-runtime/src/object/array.rs
+++ b/dolang-runtime/src/object/array.rs
@@ -18,10 +18,7 @@ use crate::{
 
 use super::{
     BoundMethod, index, iter,
-    protocol::{
-        GcObj, Inspect, Protocol, Recv, Spread, SpreadContext, default_spread,
-        dispatch_native_method,
-    },
+    protocol::{GcObj, Inspect, Protocol, Recv, Spread, SpreadContext, dispatch_native_method},
     range, tuple,
 };
 
@@ -46,18 +43,26 @@ impl<'a, 'v, 's> Spread<'v, 's> for ArraySpread<'a, 'v> {
         &mut self,
         strand: &mut Strand<'v, 's>,
         key: Sym<'v, '_>,
-        _value: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        Err(Error::unexpected_key(strand, key))
+        self.0.push(Value::from_object(tuple::tuple(
+            strand,
+            [Value::from_object(strand.sym_obj(key)), value.take()],
+        )));
+        Ok(())
     }
 
     fn keyed(
         &mut self,
         strand: &mut Strand<'v, 's>,
-        key: Slot<'v, '_>,
-        _value: Slot<'v, '_>,
+        mut key: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        Err(Error::unexpected_key(strand, key))
+        self.0.push(Value::from_object(tuple::tuple(
+            strand,
+            [key.take(), value.take()],
+        )));
+        Ok(())
     }
 }
 
@@ -900,20 +905,15 @@ impl<'v> Protocol<'v> for Array<'v> {
     async fn op_spread<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        context: SpreadContext,
+        _context: SpreadContext,
         sink: &'a mut dyn Spread<'v, 's>,
     ) -> Result<'v, 's, ()> {
-        match context {
-            SpreadContext::Sequence => {
-                let borrow = this.borrow(strand)?;
-                for item in borrow.inner.iter() {
-                    let mut tmp = item.dup();
-                    sink.positional(strand, Slot::new(&mut tmp))?;
-                }
-                Ok(())
-            }
-            _ => default_spread(strand, this.clone(), context, sink).await,
+        let borrow = this.borrow(strand)?;
+        for item in borrow.inner.iter() {
+            let mut tmp = item.dup();
+            sink.positional(strand, Slot::new(&mut tmp))?;
         }
+        Ok(())
     }
 
     async fn op_unpack<'a, 's>(

--- a/dolang-runtime/src/object/dict.rs
+++ b/dolang-runtime/src/object/dict.rs
@@ -26,6 +26,53 @@ use super::{
 
 // ── Dict newtype ────────────────────────────────────────────────────
 
+struct DictPairs<'b, 'v> {
+    int: i64,
+    dict: &'b mut Dict<'v>,
+}
+
+impl<'b, 'v, 's> Spread<'v, 's> for DictPairs<'b, 'v> {
+    fn positional(
+        &mut self,
+        strand: &mut Strand<'v, 's>,
+        mut value: Slot<'v, '_>,
+    ) -> Result<'v, 's, ()> {
+        let key = Value::from_i64(strand, self.int);
+        let hv = kv::hash(strand, &key).unwrap();
+        self.dict.0.insert(strand, key, value.take(), hv, false);
+        self.int = self
+            .int
+            .checked_add(1)
+            .ok_or_else(|| Error::overflow(strand))?;
+        Ok(())
+    }
+
+    fn symbol(
+        &mut self,
+        strand: &mut Strand<'v, 's>,
+        key: Sym<'v, '_>,
+        mut value: Slot<'v, '_>,
+    ) -> Result<'v, 's, ()> {
+        let key = Value::from_object(strand.sym_obj(key));
+        let hv = kv::hash(strand, &key).unwrap();
+        self.dict.0.insert(strand, key, value.take(), hv, false);
+        Ok(())
+    }
+
+    fn keyed(
+        &mut self,
+        strand: &mut Strand<'v, 's>,
+        mut key: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
+    ) -> Result<'v, 's, ()> {
+        let hv = kv::hash(strand, &key)?;
+        self.dict
+            .0
+            .insert(strand, key.take(), value.take(), hv, false);
+        Ok(())
+    }
+}
+
 pub(crate) struct Dict<'v>(pub(crate) Inner<'v>);
 
 impl<'v> AsRef<Inner<'v>> for Dict<'v> {
@@ -87,6 +134,11 @@ impl<'v> Dict<'v> {
         let mut counter = 1;
         let mut index = 0;
 
+        let mut sink = DictPairs {
+            int: 0,
+            dict: &mut this,
+        };
+
         loop {
             if counter % crate::INTERRUPT_INTERVAL == 0 {
                 strand.check_interrupt_gc()?
@@ -97,7 +149,7 @@ impl<'v> Dict<'v> {
                 Some(Arg::Key(sym, mut value)) if sym.tag() == sym::INT => {
                     let key = Value::from_i64(strand, index);
                     let hv = kv::hash(strand, &key).unwrap();
-                    this.0.insert(
+                    sink.dict.insert(
                         strand,
                         Value::from_i64(strand, index),
                         value.take(),
@@ -108,49 +160,6 @@ impl<'v> Dict<'v> {
                     continue;
                 }
                 Some(Arg::Key(sym, expand)) if sym.tag() == sym::ITER => {
-                    struct DictPairs<'b, 'v> {
-                        dict: &'b mut Dict<'v>,
-                    }
-
-                    impl<'b, 'v, 's> Spread<'v, 's> for DictPairs<'b, 'v> {
-                        fn positional(
-                            &mut self,
-                            strand: &mut Strand<'v, 's>,
-                            _value: Slot<'v, '_>,
-                        ) -> Result<'v, 's, ()> {
-                            Err(Error::type_error(
-                                strand,
-                                "dict spread expects key/value pairs",
-                            ))
-                        }
-
-                        fn symbol(
-                            &mut self,
-                            strand: &mut Strand<'v, 's>,
-                            key: Sym<'v, '_>,
-                            mut value: Slot<'v, '_>,
-                        ) -> Result<'v, 's, ()> {
-                            let key = Value::from_object(strand.sym_obj(key));
-                            let hv = kv::hash(strand, &key).unwrap();
-                            self.dict.0.insert(strand, key, value.take(), hv, false);
-                            Ok(())
-                        }
-
-                        fn keyed(
-                            &mut self,
-                            strand: &mut Strand<'v, 's>,
-                            mut key: Slot<'v, '_>,
-                            mut value: Slot<'v, '_>,
-                        ) -> Result<'v, 's, ()> {
-                            let hv = kv::hash(strand, &key)?;
-                            self.dict
-                                .0
-                                .insert(strand, key.take(), value.take(), hv, false);
-                            Ok(())
-                        }
-                    }
-
-                    let mut sink = DictPairs { dict: &mut this };
                     expand
                         .op_spread(strand, SpreadContext::Pairs, &mut sink)
                         .await?;
@@ -165,7 +174,8 @@ impl<'v> Dict<'v> {
                 None => return Err(Error::missing_positional(strand, counter)),
             };
             let hv = kv::hash(strand, &key)?;
-            this.0.insert(strand, key.take(), value.take(), hv, false)
+            sink.dict
+                .insert(strand, key.take(), value.take(), hv, false)
         }
 
         Ok(this)
@@ -657,51 +667,12 @@ impl<'v> Protocol<'v> for Type {
         let ([items], []) = unpack!(strand, args, 1, 0)?;
         let mut dict = Dict::new();
 
-        struct DictPairs<'b, 'v> {
-            dict: &'b mut Dict<'v>,
-        }
-
-        impl<'b, 'v, 's> Spread<'v, 's> for DictPairs<'b, 'v> {
-            fn positional(
-                &mut self,
-                strand: &mut Strand<'v, 's>,
-                _value: Slot<'v, '_>,
-            ) -> Result<'v, 's, ()> {
-                Err(Error::type_error(
-                    strand,
-                    "dict spread expects key/value pairs",
-                ))
-            }
-
-            fn symbol(
-                &mut self,
-                strand: &mut Strand<'v, 's>,
-                key: Sym<'v, '_>,
-                mut value: Slot<'v, '_>,
-            ) -> Result<'v, 's, ()> {
-                let key = Value::from_object(strand.sym_obj(key));
-                let hv = kv::hash(strand, &key).unwrap();
-                self.dict.0.insert(strand, key, value.take(), hv, false);
-                Ok(())
-            }
-
-            fn keyed(
-                &mut self,
-                strand: &mut Strand<'v, 's>,
-                mut key: Slot<'v, '_>,
-                mut value: Slot<'v, '_>,
-            ) -> Result<'v, 's, ()> {
-                let hv = kv::hash(strand, &key)?;
-                self.dict
-                    .0
-                    .insert(strand, key.take(), value.take(), hv, false);
-                Ok(())
-            }
-        }
-
         // FIXME: `dict` is not GC-scannable, but then again if it were it would also
         // be mutably borrowed, which would inhibit GC.  This needs a resolution.
-        let mut sink = DictPairs { dict: &mut dict };
+        let mut sink = DictPairs {
+            int: 0,
+            dict: &mut dict,
+        };
         items
             .op_spread(strand, SpreadContext::Pairs, &mut sink)
             .await?;

--- a/dolang-runtime/src/object/kv.rs
+++ b/dolang-runtime/src/object/kv.rs
@@ -347,13 +347,12 @@ unsafe impl<'v, T: AsRef<Inner<'v>> + Collect + 'v> Collect for KeyValues<'v, T>
 impl<'v> Inner<'v> {
     fn spread_key_value<'s>(
         strand: &mut Strand<'v, 's>,
-        context: SpreadContext,
         next_pos: &mut i64,
         mut key: Value<'v>,
         mut value: Value<'v>,
         sink: &mut dyn Spread<'v, 's>,
     ) -> Result<'v, 's, ()> {
-        if context == SpreadContext::Args && key.as_i64(strand) == Some(*next_pos) {
+        if key.as_i64(strand) == Some(*next_pos) {
             *next_pos += 1;
             sink.positional(strand, Slot::new(&mut value))
         } else if let Some(sym) = key.as_sym(strand) {
@@ -528,7 +527,7 @@ impl<'v> Inner<'v> {
         epoch: u64,
         container: &GcObj<'v, T>,
         strand: &mut Strand<'v, 's>,
-        context: SpreadContext,
+        _context: SpreadContext,
         sink: &mut dyn Spread<'v, 's>,
     ) -> Result<'v, 's, ()> {
         let container_borrow = container
@@ -551,7 +550,6 @@ impl<'v> Inner<'v> {
                 let bucket = unsafe { bucket.as_ref() };
                 Self::spread_key_value(
                     strand,
-                    context,
                     &mut next_pos,
                     bucket.key.dup(),
                     bucket.value.at(*subindex).dup(),
@@ -1171,7 +1169,7 @@ impl<'v> Inner<'v> {
     pub(crate) async fn op_spread<'a, 's, T: AsRef<Inner<'v>> + Protocol<'v> + 'v>(
         this: Recv<'v, 'a, T>,
         strand: &'a mut Strand<'v, 's>,
-        context: SpreadContext,
+        _context: SpreadContext,
         sink: &'a mut dyn Spread<'v, 's>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.borrow(strand)?;
@@ -1190,7 +1188,6 @@ impl<'v> Inner<'v> {
                 let bucket = bucket.as_ref();
                 Self::spread_key_value(
                     strand,
-                    context,
                     &mut next_pos,
                     bucket.key.dup(),
                     bucket.value.at(*subindex).dup(),
@@ -1790,7 +1787,7 @@ impl<'v, T: Protocol<'v> + AsRef<Inner<'v>> + AsMut<Inner<'v>>> UnpackInner<'v, 
     pub(crate) fn op_spread<'s>(
         this: Recv<'v, '_, impl AsMut<Self> + Protocol<'v>>,
         strand: &mut Strand<'v, 's>,
-        context: SpreadContext,
+        _context: SpreadContext,
         sink: &mut dyn Spread<'v, 's>,
     ) -> Result<'v, 's, ()> {
         let mut borrow = this.borrow_mut(strand)?;
@@ -1825,14 +1822,7 @@ impl<'v, T: Protocol<'v> + AsRef<Inner<'v>> + AsMut<Inner<'v>>> UnpackInner<'v, 
                     .as_ref()
                     .get(strand, &key, Some(0))?
                     {
-                        Inner::spread_key_value(
-                            strand,
-                            context,
-                            &mut next_pos,
-                            key,
-                            value.dup(),
-                            sink,
-                        )?;
+                        Inner::spread_key_value(strand, &mut next_pos, key, value.dup(), sink)?;
                         *int += 1;
                     } else {
                         borrow.state = UnpackState::Resume {
@@ -1863,7 +1853,6 @@ impl<'v, T: Protocol<'v> + AsRef<Inner<'v>> + AsMut<Inner<'v>>> UnpackInner<'v, 
                     }
                     Inner::spread_key_value(
                         strand,
-                        context,
                         &mut next_pos,
                         key.dup(),
                         bucket.value.at(*subindex).dup(),
@@ -1906,7 +1895,6 @@ impl<'v, T: Protocol<'v> + AsRef<Inner<'v>> + AsMut<Inner<'v>>> UnpackInner<'v, 
                     };
                     Inner::spread_key_value(
                         strand,
-                        context,
                         &mut next_pos,
                         key,
                         bucket.value.at(*subindex).dup(),

--- a/dolang-runtime/src/object/set.rs
+++ b/dolang-runtime/src/object/set.rs
@@ -18,10 +18,8 @@ use crate::{
 
 use super::{
     BoundMethod, iter, kv,
-    protocol::{
-        GcObj, Inspect, Protocol, Recv, Spread, SpreadContext, default_spread,
-        dispatch_native_method,
-    },
+    protocol::{GcObj, Inspect, Protocol, Recv, Spread, SpreadContext, dispatch_native_method},
+    tuple,
 };
 
 use dolang_util::hashbrown::raw::{Bucket, RawTable};
@@ -285,18 +283,27 @@ impl<'a, 'v, 's> Spread<'v, 's> for SetSpread<'a, 'v> {
         &mut self,
         strand: &mut Strand<'v, 's>,
         key: Sym<'v, '_>,
-        _value: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        Err(Error::unexpected_key(strand, key))
+        let pair = Value::from_object(tuple::tuple(
+            strand,
+            [Value::from_object(strand.sym_obj(key)), value.take()],
+        ));
+        let hash = kv::hash(strand, &pair)?;
+        self.0.0.insert(strand, pair, hash)?;
+        Ok(())
     }
 
     fn keyed(
         &mut self,
         strand: &mut Strand<'v, 's>,
-        key: Slot<'v, '_>,
-        _value: Slot<'v, '_>,
+        mut key: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        Err(Error::unexpected_key(strand, key))
+        let pair = Value::from_object(tuple::tuple(strand, [key.take(), value.take()]));
+        let hash = kv::hash(strand, &pair)?;
+        self.0.0.insert(strand, pair, hash)?;
+        Ok(())
     }
 }
 
@@ -757,7 +764,9 @@ impl<'v> Protocol<'v> for Type {
             let mut spread = SetSpread(&mut set);
             // FIXME: `set` is not GC-scannable, but then again if it were it would also
             // be mutably borrowed, which would inhibit GC.  This needs a resolution.
-            default_spread(strand, items, SpreadContext::Sequence, &mut spread).await?;
+            items
+                .op_spread(strand, SpreadContext::Sequence, &mut spread)
+                .await?;
             set
         } else {
             Set::new()

--- a/dolang-runtime/src/object/tuple.rs
+++ b/dolang-runtime/src/object/tuple.rs
@@ -53,18 +53,26 @@ impl<'a, 'v, 's> Spread<'v, 's> for TupleSpread<'a, 'v> {
         &mut self,
         strand: &mut Strand<'v, 's>,
         key: Sym<'v, '_>,
-        _value: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        Err(Error::unexpected_key(strand, key))
+        self.0.push(Value::from_object(tuple(
+            strand.vm(),
+            [Value::from_object(strand.sym_obj(key)), value.take()],
+        )));
+        Ok(())
     }
 
     fn keyed(
         &mut self,
         strand: &mut Strand<'v, 's>,
-        key: Slot<'v, '_>,
-        _value: Slot<'v, '_>,
+        mut key: Slot<'v, '_>,
+        mut value: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        Err(Error::unexpected_key(strand, key))
+        self.0.push(Value::from_object(tuple(
+            strand.vm(),
+            [key.take(), value.take()],
+        )));
+        Ok(())
     }
 }
 
@@ -236,6 +244,20 @@ impl<'v> Protocol<'v> for [Value<'v>] {
                     index,
                 },
             )));
+        }
+        Ok(())
+    }
+
+    async fn op_spread<'a, 's>(
+        this: Recv<'v, 'a, Self>,
+        strand: &'a mut Strand<'v, 's>,
+        _context: SpreadContext,
+        sink: &'a mut dyn Spread<'v, 's>,
+    ) -> Result<'v, 's, ()> {
+        let borrow = this.get();
+        for item in borrow.iter() {
+            let mut tmp = item.dup();
+            sink.positional(strand, Slot::new(&mut tmp))?;
         }
         Ok(())
     }


### PR DESCRIPTION
Dict spreads now renumber integer keys, making `{...foo, ...bar}` behave like syntactic concatenation of the expressions.