### PR TITLE
Use a bespoke trait for formatting output

### DIFF
--- a/dolang-ext-glob/src/glob.rs
+++ b/dolang-ext-glob/src/glob.rs
@@ -1,8 +1,9 @@
-use std::{fmt, str::FromStr};
+use std::str::FromStr;
+
+use dolang::runtime::object::fmt;
 
 use dolang::runtime::{
     Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Type, Value,
-    error::ResultExt,
     object::TypeBuilder,
     unpack,
     value::{Str, View},
@@ -114,9 +115,9 @@ impl<'v> Object<'v> for Glob {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().glob).into_do(strand)
+        fmt!(strand, w, "{}", this.annex().glob)
     }
 }
 

--- a/dolang-ext-http/src/http.rs
+++ b/dolang-ext-http/src/http.rs
@@ -6,9 +6,11 @@ use std::{
     task::{Context, Poll},
 };
 
+use dolang::runtime::object::fmt;
+
 use dolang::runtime::{
-    Arg, Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Sym, Type, Value,
-    call,
+    Arg, Args, Error, Format, Instance, Object, Output, Result, Slot, State, Strand, Sym, Type,
+    Value, call,
     error::{ErrorKind, ResultExt as _},
     method,
     object::{Mut, Ref, TypeBuilder},
@@ -38,6 +40,15 @@ use crate::{
 /// Custom error type for body streaming errors
 #[derive(Debug)]
 struct BodyError;
+
+struct BytesFormat(Vec<u8>);
+
+impl<'v> Format<'v> for BytesFormat {
+    fn write_str<'s>(&mut self, _strand: &mut Strand<'v, 's>, s: &str) -> Result<'v, 's, ()> {
+        self.0.extend_from_slice(s.as_bytes());
+        Ok(())
+    }
+}
 
 impl fmt::Display for BodyError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -271,19 +282,19 @@ impl<'v> Object<'v> for ErrorObject {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().inner).map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, "{}", this.annex().inner)
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<http.Error ").map_err(|err| Error::runtime(strand, err))?;
+        fmt!(strand, w, "<http.Error ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, ">")
     }
 }
 
@@ -345,19 +356,19 @@ impl<'v> Object<'v> for StatusObject {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().message).map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, "{}", this.annex().message)
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<http.Status ").map_err(|err| Error::runtime(strand, err))?;
+        fmt!(strand, w, "<http.Status ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, ">")
     }
 }
 
@@ -406,7 +417,9 @@ async fn pump_request_body<'v, 's>(
                         let mut vec = if let Some(slice) = item.as_bin(strand) {
                             slice.to_vec()
                         } else {
-                            item.to_string(strand)?.into()
+                            let mut format = BytesFormat(Vec::new());
+                            item.display(strand, &mut format)?;
+                            format.0
                         };
 
                         if lines {

--- a/dolang-ext-http/tests/regression/streaming_request.dol
+++ b/dolang-ext-http/tests/regression/streaming_request.dol
@@ -1,5 +1,11 @@
 import http
 
+class RequestBody
+  pub field value = "custom body"
+
+  def (str) self
+    self.value
+
 # Test backward compatibility with string body
 http.post $TEST_URL/post body: "simple string" do |res|
   assert_eq $res.status 201
@@ -14,6 +20,11 @@ http.post $TEST_URL/post body: b"hello" do |res|
 http.post $TEST_URL/post body: ["hello", "world"] do |res|
   assert_eq $res.status 201
   assert_eq $res.text() "helloworld"
+
+# Test streaming values formatted through the public runtime sink API
+http.post $TEST_URL/post body: [RequestBody()] do |res|
+  assert_eq $res.status 201
+  assert_eq $res.text() "custom body"
 
 # Test streaming from array of binary data (no delimiters)
 http.post $TEST_URL/post body: [b"hello", b"world"] do |res|

--- a/dolang-ext-patch/src/patch.rs
+++ b/dolang-ext-patch/src/patch.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, fmt, mem, path::PathBuf, result};
+use std::{borrow::Cow, mem, path::PathBuf, result};
 
 #[cfg(unix)]
 use std::os::unix::ffi::OsStringExt;
@@ -9,6 +9,8 @@ use diffy::{
     binary::{BinaryBlock, BinaryPatch},
     patch_set::{FileMode, FileOperation, FilePatch, ParseOptions, PatchKind, PatchSet},
 };
+use dolang::runtime::object::fmt;
+
 use dolang::runtime::{
     Error, Instance, Object, Output, Result, Slot, State, Strand, Value,
     error::ResultExt,
@@ -368,19 +370,19 @@ impl<'v> Object<'v> for ParseError {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().message).map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, "{}", this.annex().message)
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<patch.ParseError ").map_err(|err| Error::runtime(strand, err))?;
+        fmt!(strand, w, "<patch.ParseError ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, ">")
     }
 }
 
@@ -398,19 +400,19 @@ impl<'v> Object<'v> for ApplyError {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().message).map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, "{}", this.annex().message)
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<patch.ApplyError ").map_err(|err| Error::runtime(strand, err))?;
+        fmt!(strand, w, "<patch.ApplyError ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, ">")
     }
 }
 

--- a/dolang-ext-progress/src/progress.rs
+++ b/dolang-ext-progress/src/progress.rs
@@ -1,15 +1,16 @@
 use std::{
     cell::{Cell, RefCell},
-    fmt, io,
+    io,
     pin::Pin,
     rc::Rc,
     task::{Context as TaskContext, Poll},
     time::Duration,
 };
 
+use dolang::runtime::object::fmt;
+
 use dolang::runtime::{
     Error, Instance, Object, Output, Result, State, Strand, Value, call,
-    error::ResultExt,
     object::TypeBuilder,
     strand::{self, Local},
     unpack,
@@ -559,9 +560,9 @@ impl<'v> Object<'v> for Indicator {
     fn debug<'a, 's>(
         _this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<progress.Indicator>").into_do(strand)
+        fmt!(strand, w, "<progress.Indicator>")
     }
 
     fn build<'a>(builder: TypeBuilder<'v, 'a, Self>) -> TypeBuilder<'v, 'a, Self> {

--- a/dolang-ext-regex/src/regex.rs
+++ b/dolang-ext-regex/src/regex.rs
@@ -1,4 +1,6 @@
-use std::{borrow::Cow, fmt, mem};
+use std::{borrow::Cow, mem};
+
+use dolang::runtime::object::fmt;
 
 use dolang::runtime::{
     Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Type, Value, call,
@@ -429,9 +431,10 @@ impl<'v> Object<'v> for Captures<'v> {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", &this.borrow(strand)?.caps[0]).into_do(strand)
+        let borrow = this.borrow(strand)?;
+        fmt!(strand, w, "{}", &borrow.caps[0])
     }
 
     fn index<'a, 's>(
@@ -538,9 +541,10 @@ impl<'v> Object<'v> for Match<'v> {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.borrow(strand)?.match_.as_str()).into_do(strand)
+        let borrow = this.borrow(strand)?;
+        fmt!(strand, w, "{}", borrow.match_.as_str())
     }
 
     fn build<'a>(builder: TypeBuilder<'v, 'a, Self>) -> TypeBuilder<'v, 'a, Self> {

--- a/dolang-ext-shell/src/error.rs
+++ b/dolang-ext-shell/src/error.rs
@@ -1,5 +1,7 @@
 use std::{fmt, io, marker::PhantomData};
 
+use dolang::runtime::object::fmt;
+
 use dolang::runtime::{
     Error, Instance, Object, Output, Result, Strand, Type, object::TypeBuilder, value::TypeObject,
 };
@@ -142,19 +144,19 @@ impl<'v, T: SysErrorType<'v>> Object<'v> for SysErrorObject<T> {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().message()).map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, "{}", this.annex().message())
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<sys.{} ", T::NAME).map_err(|err| Error::runtime(strand, err))?;
+        fmt!(strand, w, "<sys.{} ", T::NAME)?;
         Self::display(this, strand, w)?;
-        write!(w, ">").map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, ">")
     }
 }
 
@@ -277,19 +279,19 @@ impl<'v> Object<'v> for ProcError {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().message()).map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, "{}", this.annex().message())
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<proc.Error ").map_err(|err| Error::runtime(strand, err))?;
+        fmt!(strand, w, "<proc.Error ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").map_err(|err| Error::runtime(strand, err))
+        fmt!(strand, w, ">")
     }
 }
 

--- a/dolang-ext-shell/src/fs/path.rs
+++ b/dolang-ext-shell/src/fs/path.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     hash::{Hash, Hasher},
     marker::PhantomData,
 };
@@ -9,9 +8,10 @@ use crate::{
     fs::{path_absolute, path_relative},
     global::Global,
 };
+use dolang::runtime::object::fmt;
+
 use dolang::runtime::{
     Arg, Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Type, Value,
-    error::ResultExt,
     object::{ArrayLike, ArrayView, TypeBuilder},
     unpack,
 };
@@ -465,25 +465,25 @@ macro_rules! impl_concrete_path {
             fn debug<'a, 's>(
                 this: Instance<'v, 'a, Self>,
                 strand: &'a mut Strand<'v, 's>,
-                w: &mut dyn fmt::Write,
+                w: &mut dyn dolang::runtime::Format<'v>,
             ) -> Result<'v, 's, ()> {
-                write!(w, "<Path {:?}>", this.annex().display()).into_do(strand)
+                fmt!(strand, w, "<Path {:?}>", this.annex().display())
             }
 
             fn display<'a, 's>(
                 this: Instance<'v, 'a, Self>,
                 strand: &'a mut Strand<'v, 's>,
-                w: &mut dyn fmt::Write,
+                w: &mut dyn dolang::runtime::Format<'v>,
             ) -> Result<'v, 's, ()> {
-                write!(w, "{}", this.annex().display()).into_do(strand)
+                fmt!(strand, w, "{}", this.annex().display())
             }
 
             fn display_arg<'a, 's>(
                 this: Instance<'v, 'a, Self>,
                 strand: &'a mut Strand<'v, 's>,
-                w: &mut dyn fmt::Write,
+                w: &mut dyn dolang::runtime::Format<'v>,
             ) -> Result<'v, 's, ()> {
-                write!(w, "{}", this.annex().display()).into_do(strand)
+                fmt!(strand, w, "{}", this.annex().display())
             }
 
             fn build<'a>(mut builder: TypeBuilder<'v, 'a, Self>) -> TypeBuilder<'v, 'a, Self> {

--- a/dolang-ext-shell/src/fs/readdir.rs
+++ b/dolang-ext-shell/src/fs/readdir.rs
@@ -1,8 +1,8 @@
-use std::fmt;
+use dolang::runtime::object::fmt;
 
 use dolang::runtime::{
-    Error, Instance, Object, Output, Result, Slot, State, Strand, Value, error::ResultExt as _,
-    object::TypeBuilder, value::TypeObject,
+    Error, Instance, Object, Output, Result, Slot, State, Strand, Value, object::TypeBuilder,
+    value::TypeObject,
 };
 use dolang_shell_vfs::{
     DirEntry as VfsDirEntry, FileType, ReadDir, Utf8TypedPath, Utf8TypedPathBuf,
@@ -61,9 +61,9 @@ impl<'v> Object<'v> for DirEntry {
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<fs.DirEntry {:?}>", this.annex().name).into_do(strand)
+        fmt!(strand, w, "<fs.DirEntry {:?}>", this.annex().name)
     }
 
     fn build<'a>(mut builder: TypeBuilder<'v, 'a, Self>) -> TypeBuilder<'v, 'a, Self> {

--- a/dolang-ext-shell/src/pipe_channel.rs
+++ b/dolang-ext-shell/src/pipe_channel.rs
@@ -10,7 +10,7 @@ use std::{
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 use dolang::runtime::{
-    Error, Instance, Object, Output, Result, Slot, State, Strand, Value,
+    Error, Format, Instance, Object, Output, Result, Slot, State, Strand, Value,
     object::{Mut, Ref, TypeBuilder},
     unpack,
     value::{Nil, TypeObject, View},
@@ -25,6 +25,15 @@ use crate::{
 
 type StdioSend = <AnyVfs as Vfs>::StdioSend;
 type StdioRecv = <AnyVfs as Vfs>::StdioRecv;
+
+struct BytesFormat(Vec<u8>);
+
+impl<'v> Format<'v> for BytesFormat {
+    fn write_str<'s>(&mut self, _strand: &mut Strand<'v, 's>, s: &str) -> Result<'v, 's, ()> {
+        self.0.extend_from_slice(s.as_bytes());
+        Ok(())
+    }
+}
 
 // ---------------------------------------------------------------------------
 // State machine
@@ -717,12 +726,12 @@ fn encode_value<'v, 's>(
         }
         View::Bin(s) => Ok(s.into()),
         _ => {
-            let s = value.to_string(strand)?;
-            let mut bytes = s.as_bytes().to_vec();
+            let mut format = BytesFormat(Vec::new());
+            value.display(strand, &mut format)?;
             if channel_mode == ChannelMode::Line {
-                bytes.push(b'\n');
+                format.0.push(b'\n');
             }
-            Ok(bytes)
+            Ok(format.0)
         }
     }
 }

--- a/dolang-ext-shell/src/proc.rs
+++ b/dolang-ext-shell/src/proc.rs
@@ -1,10 +1,9 @@
-use std::fmt;
+use dolang::runtime::object::fmt;
 
 use dolang::{
     compile::Compiler,
     runtime::{
         Error, Instance, Object, Output, Result, Slot, State, Strand,
-        error::ResultExt,
         object::TypeBuilder,
         strand::Redirect,
         unpack,
@@ -44,9 +43,9 @@ impl<'v> Object<'v> for Capture {
     fn debug<'a, 's>(
         _this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<capture>").into_do(strand)
+        fmt!(strand, w, "<capture>")
     }
 
     async fn output<'a, 's>(
@@ -64,11 +63,7 @@ impl<'v> Object<'v> for Capture {
         value: Slot<'v, 'a>,
     ) -> Result<'v, 's, ()> {
         let mut capture = this.borrow_mut(strand)?;
-        if let Some(str) = value.as_str(strand) {
-            strand.access(|x| capture.0.push_str(str.as_str(x)));
-        } else {
-            capture.0.push_str(&value.to_string(strand)?);
-        }
+        value.display(strand, &mut capture.0)?;
         capture.0.push('\n');
         Ok(())
     }

--- a/dolang-ext-shell/src/program.rs
+++ b/dolang-ext-shell/src/program.rs
@@ -1,12 +1,10 @@
-use std::fmt;
-
 use futures::future::MaybeDone;
 use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt, BufReader};
 
+use dolang::runtime::object::fmt;
+
 use dolang::runtime::{
-    Arg, Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Sym, Value,
-    error::ResultExt as _,
-    method,
+    Arg, Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Sym, Value, method,
     object::TypeBuilder,
     unpack,
     value::{Nil, Singleton},
@@ -755,9 +753,9 @@ impl<'v> Object<'v> for Program {
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<proc.Program {:?}>", this.annex().name).into_do(strand)
+        fmt!(strand, w, "<proc.Program {:?}>", this.annex().name)
     }
 }
 

--- a/dolang-ext-shell/src/security.rs
+++ b/dolang-ext-shell/src/security.rs
@@ -1,11 +1,9 @@
-use std::fmt;
+use dolang::runtime::object::fmt;
 
 use dolang::{
     compile::Compiler,
     runtime::{
-        Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Type, Value,
-        error::ResultExt as _,
-        method,
+        Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Type, Value, method,
         object::{ArrayLike, ArrayView, Mut, Ref, TypeBuilder},
         unpack,
         value::{AsTuple, Empty, Nil, View},
@@ -178,17 +176,17 @@ impl<'v> Object<'v> for Sid {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().as_ref()).into_do(strand)
+        fmt!(strand, w, "{}", this.annex().as_ref())
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<security.Sid {}>", this.annex().as_ref()).into_do(strand)
+        fmt!(strand, w, "<security.Sid {}>", this.annex().as_ref())
     }
 }
 

--- a/dolang-ext-shell/src/shell.rs
+++ b/dolang-ext-shell/src/shell.rs
@@ -5,6 +5,8 @@ use std::{
 
 use tokio::io::{self, AsyncBufReadExt, AsyncWriteExt, BufReader};
 
+use dolang::runtime::object::fmt;
+
 use dolang::{
     compile::Compiler,
     runtime::{
@@ -31,8 +33,6 @@ use dolang_shell_vfs::{AnyVfs, Client, Query, SecurityInfo, TargetInfo, Utf8Type
 use std::collections::HashMap;
 #[cfg(unix)]
 use std::path::PathBuf;
-
-use dolang::runtime::error::ResultExt;
 
 use crate::error;
 
@@ -295,14 +295,18 @@ impl<'v> Object<'v> for Vfs {
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
         match &this.annex().source {
-            VfsSource::Stream => write!(w, "<shell.Vfs stream>").into_do(strand),
+            VfsSource::Stream => fmt!(strand, w, "<shell.Vfs stream>"),
             #[cfg(unix)]
-            VfsSource::Unix(socket) => write!(w, "<shell.Vfs socket: {socket:?}>").into_do(strand),
+            VfsSource::Unix(socket) => {
+                fmt!(strand, w, "<shell.Vfs socket: {socket:?}>")
+            }
             #[cfg(windows)]
-            VfsSource::Windows(_) => write!(w, "<shell.Vfs windows admin>").into_do(strand),
+            VfsSource::Windows(_) => {
+                fmt!(strand, w, "<shell.Vfs windows admin>")
+            }
         }
     }
 

--- a/dolang-ext-shell/src/time.rs
+++ b/dolang-ext-shell/src/time.rs
@@ -1,4 +1,6 @@
-use std::{fmt, io, time::SystemTime};
+use std::{io, time::SystemTime};
+
+use dolang::runtime::object::fmt;
 
 use dolang::{
     compile::Compiler,
@@ -94,13 +96,17 @@ impl DurationAnnex {
         self.total_nanos as f64 / NANOS_PER_SEC_F64
     }
 
-    fn write_seconds(&self, w: &mut dyn fmt::Write) -> fmt::Result {
+    fn write_seconds<'v, 's>(
+        &self,
+        strand: &mut Strand<'v, 's>,
+        w: &mut dyn dolang::runtime::Format<'v>,
+    ) -> Result<'v, 's, ()> {
         if self.total_nanos == 0 {
-            return write!(w, "0s");
+            return fmt!(strand, w, "0s");
         }
 
         if self.total_nanos < 0 {
-            write!(w, "-")?;
+            fmt!(strand, w, "-")?;
         }
 
         let abs_nanos = self.total_nanos.unsigned_abs();
@@ -108,7 +114,7 @@ impl DurationAnnex {
         let nanos = abs_nanos % (NANOS_PER_SEC_I128 as u128);
 
         if nanos == 0 {
-            return write!(w, "{}s", secs);
+            return fmt!(strand, w, "{}s", secs);
         }
 
         let mut frac = format!("{:09}", nanos);
@@ -116,7 +122,7 @@ impl DurationAnnex {
             frac.pop();
         }
 
-        write!(w, "{}.{}s", secs, frac)
+        fmt!(strand, w, "{}.{}s", secs, frac)
     }
 
     fn to_std_duration<'v, 's>(
@@ -330,20 +336,20 @@ impl<'v> Object<'v> for DateTime {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let formatted = format_datetime_rfc3339(strand, &this.annex())?;
-        write!(w, "{}", formatted).into_do(strand)
+        fmt!(strand, w, "{}", formatted)
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<DateTime ").into_do(strand)?;
+        fmt!(strand, w, "<DateTime ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").into_do(strand)
+        fmt!(strand, w, ">")
     }
 
     fn eq<'a, 's>(
@@ -417,19 +423,19 @@ impl<'v> Object<'v> for Duration {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        this.annex().write_seconds(w).into_do(strand)
+        this.annex().write_seconds(strand, w)
     }
 
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<Duration ").into_do(strand)?;
+        fmt!(strand, w, "<Duration ")?;
         Self::display(this, strand, w)?;
-        write!(w, ">").into_do(strand)
+        fmt!(strand, w, ">")
     }
 
     fn eq<'a, 's>(

--- a/dolang-ext-sqlite/src/sqlite/mod.rs
+++ b/dolang-ext-sqlite/src/sqlite/mod.rs
@@ -1,10 +1,11 @@
 use std::{
     cell::Cell,
     ffi::{CStr, CString},
-    fmt,
     path::Path,
     ptr,
 };
+
+use dolang::runtime::object::fmt;
 
 use dolang::runtime::{
     Error, Instance, Object, Result, State, Strand, call, error::ResultExt, method, unpack,
@@ -279,9 +280,9 @@ impl<'v> Object<'v> for SqliteError {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().1).into_do(strand)
+        fmt!(strand, w, "{}", this.annex().1)
     }
 }
 
@@ -295,8 +296,8 @@ impl<'v> Object<'v> for SqliteBusy {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().1).into_do(strand)
+        fmt!(strand, w, "{}", this.annex().1)
     }
 }

--- a/dolang-ext-url/src/url.rs
+++ b/dolang-ext-url/src/url.rs
@@ -1,7 +1,6 @@
-use std::{
-    fmt,
-    hash::{Hash, Hasher},
-};
+use std::hash::{Hash, Hasher};
+
+use dolang::runtime::object::fmt;
 
 use dolang::runtime::{
     Args, Error, Instance, Object, Output, Result, Slot, State, Strand, Type, Value,
@@ -197,17 +196,17 @@ impl<'v> Object<'v> for Url {
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<url.Url {:?}>", this.annex().inner.as_str()).into_do(strand)
+        fmt!(strand, w, "<url.Url {:?}>", this.annex().inner.as_str())
     }
 
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.annex().inner).into_do(strand)
+        fmt!(strand, w, "{}", this.annex().inner)
     }
 
     fn build<'a>(builder: TypeBuilder<'v, 'a, Self>) -> TypeBuilder<'v, 'a, Self> {

--- a/dolang-ext-xml/src/node.rs
+++ b/dolang-ext-xml/src/node.rs
@@ -1,8 +1,7 @@
-use std::fmt;
+use dolang::runtime::object::fmt;
 
 use dolang::runtime::{
     Args, Error, Instance, Object, Output, Result, Slot, Strand, Type, Value,
-    error::ResultExt,
     object::{ArrayLike, ArrayView, DictLike, DictView, DictViewSink, Mut, Ref, TypeBuilder},
     unpack,
     value::{Empty, Nil, TypeObject},
@@ -139,10 +138,10 @@ impl<'v> Object<'v> for Node {
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.borrow(strand)?;
-        write!(w, "<xml.Node {}>", borrow.tag).into_do(strand)
+        fmt!(strand, w, "<xml.Node {}>", borrow.tag)
     }
 
     fn index<'a, 's>(

--- a/dolang-private-regression/tests/regression.rs
+++ b/dolang-private-regression/tests/regression.rs
@@ -1,6 +1,8 @@
 #![deny(warnings)]
 
 mod detail {
+    use dolang::runtime::object::fmt;
+
     use dolang::{
         compile::{self, Compiler, Mode},
         runtime::{
@@ -8,9 +10,9 @@ mod detail {
             vm::Builder,
         },
     };
-    use dolang_runtime::{error::ResultExt, strand::Strand};
+    use dolang_runtime::strand::Strand;
     use std::{
-        fmt, io,
+        io,
         ops::ControlFlow,
         path::{Path, PathBuf},
         pin::Pin,
@@ -106,7 +108,7 @@ mod detail {
         fn display<'a, 's>(
             this: Instance<'v, 'a, Self>,
             strand: &'a mut Strand<'v, 's>,
-            w: &mut dyn fmt::Write,
+            w: &mut dyn dolang::runtime::Format<'v>,
         ) -> runtime::Result<'v, 's, ()> {
             Self::debug(this, strand, w)
         }
@@ -114,9 +116,9 @@ mod detail {
         fn debug<'a, 's>(
             _this: Instance<'v, 'a, Self>,
             strand: &'a mut Strand<'v, 's>,
-            w: &mut dyn fmt::Write,
+            w: &mut dyn dolang::runtime::Format<'v>,
         ) -> runtime::Result<'v, 's, ()> {
-            write!(w, "foo").into_do(strand)
+            fmt!(strand, w, "foo")
         }
     }
 

--- a/dolang-private-regression/tests/regression/runtime/convert.dol
+++ b/dolang-private-regression/tests/regression/runtime/convert.dol
@@ -1,3 +1,6 @@
+import std:
+  - arg
+
 def assert_err block msg
   let res = try
     block()
@@ -48,3 +51,11 @@ assert_eq  (str(1.0 / 0.0)) "inf"
 assert_eq  (str(-1.0 / 0.0)) "-inf"
 assert_eq  (str(0.0 / 0.0)) "NaN"
 assert_eq  (str "foo") "foo"
+
+# Streaming conversions through a native object's formatting implementation
+let foo = makefoo()
+assert_eq (str foo) "foo"
+assert_eq (dbg foo) "foo"
+assert_eq (arg foo) "foo"
+assert_eq "before-$(foo)-after" "before-foo-after"
+assert_eq (",".join [foo, 2, [3]]) "foo,2,[3]"

--- a/dolang-private-regression/tests/regression/runtime/str/misc.dol
+++ b/dolang-private-regression/tests/regression/runtime/str/misc.dol
@@ -35,6 +35,8 @@ assert_eq [..."a,b,c".rsplit ","] ["c", "b", "a"]
 assert_eq [..."a,b,c".rsplit "," limit: 1] ["c", "a,b"]
 assert_eq [..."a,b,c".rsplit "," limit: -1] ["b,c", "a"]
 assert_eq (",".join ["a", "b", "c"]) "a,b,c"
+assert_eq (",".join []) ""
+assert_eq (",".join (["only"])) "only"
 assert_eq ("foo bar foo".replace "foo" "baz") "baz bar baz"
 assert_eq ("banana".replace "na" "") "ba"
 assert_eq ("abc".replace "" "-") "-a-b-c-"

--- a/dolang-runtime/src/interp.rs
+++ b/dolang-runtime/src/interp.rs
@@ -30,7 +30,7 @@ use crate::{
     strand::{Strand, StrandInner},
     sym::{self, Sym},
     unpack,
-    value::{Output, Slot, Slots, Value},
+    value::{Output, Slot, Slots, StrEmbryo, Value},
     vm::{ImportCacheEntry, ImportGuard, Vm},
 };
 
@@ -297,9 +297,9 @@ impl<'v> Vm<'v> {
         &self,
         strand: &'a mut Strand<'v, 's>,
         args: Args<'v, 'a>,
-        mut out: Slot<'v, '_>,
+        out: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        let mut acc = String::new();
+        let mut acc = StrEmbryo::new();
         for arg in args {
             let value = match arg {
                 Arg::Pos(mut slot) => slot.take(),
@@ -307,7 +307,7 @@ impl<'v> Vm<'v> {
             };
             value.op_display(strand, &mut acc)?;
         }
-        out.store(Value::from_str(strand, &acc));
+        acc.finish(strand, out);
         Ok(())
     }
 
@@ -336,9 +336,9 @@ impl<'v> Vm<'v> {
         &self,
         strand: &'a mut Strand<'v, 's>,
         args: Args<'v, 'a>,
-        mut out: Slot<'v, '_>,
+        out: Slot<'v, '_>,
     ) -> Result<'v, 's, ()> {
-        let mut acc = String::new();
+        let mut acc = StrEmbryo::new();
         for arg in args {
             let value = match arg {
                 Arg::Pos(mut slot) => slot.take(),
@@ -346,7 +346,7 @@ impl<'v> Vm<'v> {
             };
             value.op_display_arg(strand, &mut acc)?;
         }
-        out.store(Value::from_str(strand, &acc));
+        acc.finish(strand, out);
         Ok(())
     }
 

--- a/dolang-runtime/src/lib.rs
+++ b/dolang-runtime/src/lib.rs
@@ -1,5 +1,17 @@
 #![deny(warnings)]
 
+/// Writes formatted data to a [`Format`](crate::value::Format) destination.
+#[macro_export]
+macro_rules! fmt {
+    ($strand:expr, $destination:expr, $($arg:tt)*) => {
+        $crate::value::Format::write_fmt(
+            $destination,
+            $strand,
+            format_args!($($arg)*),
+        )
+    };
+}
+
 pub mod arg;
 pub mod error;
 pub mod frame;

--- a/dolang-runtime/src/object/arg.rs
+++ b/dolang-runtime/src/object/arg.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashSet, fmt, ops::ControlFlow};
+use std::{collections::HashSet, ops::ControlFlow};
 
 use crate::{
     arg::{Arg, Args},
     bytecode::Variadic,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::{BoundMethod, iter, sym::SymObj},
     sig,
@@ -290,9 +290,9 @@ impl<'v> Protocol<'v> for ArgPack<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<args>").into_do(strand)
+        crate::fmt!(strand, w, "<args>")
     }
 
     async fn op_iter<'a, 's>(
@@ -481,9 +481,9 @@ impl<'v> Protocol<'v> for ArgIter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<arg iter>").into_do(strand)
+        crate::fmt!(strand, w, "<arg iter>")
     }
 
     async fn op_iter<'a, 's>(

--- a/dolang-runtime/src/object/array.rs
+++ b/dolang-runtime/src/object/array.rs
@@ -1,4 +1,4 @@
-use std::{fmt, mem, ops::ControlFlow};
+use std::{mem, ops::ControlFlow};
 
 use dolang_util::pairsort;
 
@@ -6,7 +6,7 @@ use crate::{
     arg::{Arg, Args},
     bytecode::Variadic,
     call,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     sig::{Unpack, UnpackKeyKind},
     strand::Strand,
@@ -76,9 +76,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<array iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<array iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -181,7 +181,7 @@ impl<'v> Protocol<'v> for Sink<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::op_debug(this, strand, w)
     }
@@ -189,9 +189,9 @@ impl<'v> Protocol<'v> for Sink<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<array sink>").into_do(strand)
+        crate::fmt!(strand, w, "<array sink>")
     }
 
     async fn op_sink<'a, 's>(
@@ -268,7 +268,7 @@ impl<'v> Protocol<'v> for Pairs<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::op_debug(this, strand, w)
     }
@@ -276,9 +276,9 @@ impl<'v> Protocol<'v> for Pairs<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<array pair iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<array pair iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -513,10 +513,10 @@ impl<'v> Protocol<'v> for Array<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let this_borrow = this.borrow(strand)?;
-        write!(w, "[").into_do(strand)?;
+        crate::fmt!(strand, w, "[")?;
         let inner = &this_borrow.inner;
         let mut iter = inner.iter();
         if let Some(first) = iter.next() {
@@ -525,11 +525,11 @@ impl<'v> Protocol<'v> for Array<'v> {
                 if (i + 1) % crate::INTERRUPT_INTERVAL == 0 {
                     strand.check_trap()?;
                 }
-                write!(w, ", ").into_do(strand)?;
+                crate::fmt!(strand, w, ", ")?;
                 unsafe { inner.get_unchecked(i) }.op_debug(strand, w)?;
             }
         }
-        write!(w, "]").into_do(strand)
+        crate::fmt!(strand, w, "]")
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, strand: &mut Strand<'v, 's>) -> bool {
@@ -1176,9 +1176,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.array>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.array>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/array_view.rs
+++ b/dolang-runtime/src/object/array_view.rs
@@ -1,6 +1,6 @@
 //! Lazy array-like projections over native objects.
 
-use std::{fmt, marker::PhantomData, ops::ControlFlow, ptr};
+use std::{marker::PhantomData, ops::ControlFlow, ptr};
 
 use dolang_bytecode::Variadic;
 
@@ -189,10 +189,9 @@ fn debug<'v, 's>(
     module: &str,
     name: &str,
     strand: &mut Strand<'v, 's>,
-    w: &mut dyn fmt::Write,
+    w: &mut dyn crate::value::Format<'v>,
 ) -> Result<'v, 's, ()> {
-    use crate::error::ResultExt as _;
-    write!(w, "<{module}.{name}>").into_do(strand)
+    crate::fmt!(strand, w, "<{module}.{name}>")
 }
 
 fn normalize<'v, 's>(
@@ -216,7 +215,7 @@ impl<'v> Protocol<'v> for View<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.borrow(strand)?;
         debug(borrow.glue.module(), borrow.glue.name(), strand, w)
@@ -357,7 +356,7 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.borrow(strand)?;
         debug(borrow.glue.module(), borrow.glue.name(), strand, w)

--- a/dolang-runtime/src/object/backtrace.rs
+++ b/dolang-runtime/src/object/backtrace.rs
@@ -1,7 +1,7 @@
-use std::{fmt, ops::ControlFlow};
+use std::ops::ControlFlow;
 
 use crate::{
-    error::{BacktraceIter, Error, Result, ResultExt, UnwindEntry},
+    error::{BacktraceIter, Error, Result, UnwindEntry},
     gc::{Collect, arena::Visit},
     strand::Strand,
     sym::{self, Sym},
@@ -81,9 +81,9 @@ impl<'v> Protocol<'v> for Backtrace<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<backtrace>").into_do(strand)
+        crate::fmt!(strand, w, "<backtrace>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -161,9 +161,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<backtrace.iter>").into_do(strand)
+        crate::fmt!(strand, w, "<backtrace.iter>")
     }
 
     async fn op_next<'a, 's>(
@@ -216,9 +216,9 @@ impl<'v> Protocol<'v> for Frame<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<backtrace frame>").into_do(strand)
+        crate::fmt!(strand, w, "<backtrace frame>")
     }
 
     fn op_get<'a, 's>(
@@ -293,9 +293,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type strand.Backtrace>").into_do(strand)
+        crate::fmt!(strand, w, "<type strand.Backtrace>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/bin.rs
+++ b/dolang-runtime/src/object/bin.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     hash::{DefaultHasher, Hash},
     ops::ControlFlow,
 };
@@ -7,7 +6,7 @@ use std::{
 use crate::{
     arg::Args,
     bytecode::Variadic,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::protocol::GcObj,
     sig,
@@ -77,17 +76,17 @@ impl<'v> Protocol<'v> for [u8] {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", BStr::new(this.receiver.get())).into_do(strand)
+        crate::fmt!(strand, w, "{}", BStr::new(this.receiver.get()))
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "b{:?}", BStr::new(this.receiver.get())).into_do(strand)
+        crate::fmt!(strand, w, "b{:?}", BStr::new(this.receiver.get()))
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &'a mut Strand<'v, 's>) -> bool {
@@ -522,7 +521,7 @@ impl<'v> Protocol<'v> for Split<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let forward = this.borrow_mut(strand)?.forward;
         let label = if forward {
@@ -530,7 +529,7 @@ impl<'v> Protocol<'v> for Split<'v> {
         } else {
             "<bin rsplit>"
         };
-        write!(w, "{label}").into_do(strand)
+        crate::fmt!(strand, w, "{label}")
     }
 
     async fn op_iter<'a, 's>(
@@ -656,9 +655,9 @@ impl<'v> Protocol<'v> for Class {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.bin>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.bin>")
     }
 
     async fn op_call<'a, 's>(

--- a/dolang-runtime/src/object/channel.rs
+++ b/dolang-runtime/src/object/channel.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::VecDeque,
-    fmt, mem,
+    mem,
     ops::ControlFlow,
     pin::Pin,
     task::{self, Poll, Waker},
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{self, Collect, arena::Visit},
     strand::{Strand, StrandInner},
     sym::{self, Sym},
@@ -225,9 +225,9 @@ impl<'v> Protocol<'v> for Receiver<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<channel recv>").into_do(strand)
+        crate::fmt!(strand, w, "<channel recv>")
     }
 
     fn op_next<'a, 's>(
@@ -348,9 +348,9 @@ impl<'v> Protocol<'v> for Sender<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<channel send>").into_do(strand)
+        crate::fmt!(strand, w, "<channel send>")
     }
 
     fn op_put<'a, 's>(

--- a/dolang-runtime/src/object/class.rs
+++ b/dolang-runtime/src/object/class.rs
@@ -1,11 +1,11 @@
-use std::{cell::OnceCell, fmt, ops::ControlFlow};
+use std::{cell::OnceCell, ops::ControlFlow};
 
 use dolang_util::alias;
 
 use crate::{
     arg::Args,
     call,
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, Result},
     gc::{Annex, Collect, arena::Visit},
     method,
     object::{
@@ -49,9 +49,9 @@ impl<'v> Protocol<'v> for Getter {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Getter>").into_do(strand)
+        crate::fmt!(strand, w, "<type Getter>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -88,9 +88,9 @@ impl<'v> Protocol<'v> for Setter {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Setter>").into_do(strand)
+        crate::fmt!(strand, w, "<type Setter>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -246,13 +246,13 @@ impl<'v> Protocol<'v> for ClassObject<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let this = this.get();
         if let Some(module_name) = &this.module_name {
-            write!(w, "<type {module_name}.{}>", this.name).into_do(strand)
+            crate::fmt!(strand, w, "<type {module_name}.{}>", this.name)
         } else {
-            write!(w, "<type {}>", this.name).into_do(strand)
+            crate::fmt!(strand, w, "<type {}>", this.name)
         }
     }
 
@@ -706,7 +706,7 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let res = {
             let w = &mut *w;
@@ -717,7 +717,7 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
                     let result = result
                         .as_str_raw(strand)
                         .ok_or_else(|| Error::type_error(strand, "expected str result"))?;
-                    write!(w, "{result}").into_do(strand)?;
+                    crate::fmt!(strand, w, "{result}")?;
                     Ok(false)
                 })?,
                 Some(ClassEntry::Delegate(slot)) => {
@@ -740,7 +740,7 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let annex = this.annex();
         match annex.class.entry_by_tag(sym::DBG_METHOD) {
@@ -749,7 +749,7 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
                 let result = result
                     .as_str_raw(strand)
                     .ok_or_else(|| Error::type_error(strand, "expected str result"))?;
-                write!(w, "{result}").into_do(strand)
+                crate::fmt!(strand, w, "{result}")
             }),
             Some(ClassEntry::Delegate(slot)) => {
                 let native = annex.natives[*slot]
@@ -759,9 +759,9 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
             }
             _ => {
                 if let Some(module) = &annex.class.module_name {
-                    write!(w, "<{module}.{}>", annex.class.name).into_do(strand)
+                    crate::fmt!(strand, w, "<{module}.{}>", annex.class.name)
                 } else {
-                    write!(w, "<{}>", annex.class.name).into_do(strand)
+                    crate::fmt!(strand, w, "<{}>", annex.class.name)
                 }
             }
         }
@@ -770,7 +770,7 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
     fn op_display_arg<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let res = {
             let w = &mut *w;
@@ -783,7 +783,7 @@ impl<'v> Protocol<'v> for ClassInstance<'v> {
                         let result = result
                             .as_str_raw(strand)
                             .ok_or_else(|| Error::type_error(strand, "expected str result"))?;
-                        write!(w, "{result}").into_do(strand)?;
+                        crate::fmt!(strand, w, "{result}")?;
                         Ok(false)
                     })?
                 }

--- a/dolang-runtime/src/object/dict.rs
+++ b/dolang-runtime/src/object/dict.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::{Cell, RefCell},
-    fmt,
     ops::ControlFlow,
 };
 
@@ -9,7 +8,7 @@ use bitvec::bitbox;
 use crate::{
     arg::{Arg, Args},
     call,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     sig,
     strand::Strand,
@@ -215,9 +214,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<dict iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<dict iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -320,9 +319,9 @@ impl<'v> Protocol<'v> for Unpack<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<dict unpack iter>").into_do(strand)
+        crate::fmt!(strand, w, "<dict unpack iter>")
     }
 
     async fn op_iter<'a, 's>(
@@ -404,7 +403,7 @@ impl<'v> Protocol<'v> for Dict<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         kv::Inner::op_debug(this, strand, w, "{", "}", ", ")
     }
@@ -749,10 +748,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        use crate::error::ResultExt;
-        write!(w, "<type std.dict>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.dict>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/dict_view.rs
+++ b/dolang-runtime/src/object/dict_view.rs
@@ -1,12 +1,12 @@
 //! Lazy dictionary-like projections over native objects.
 
-use std::{fmt, marker::PhantomData, ops::ControlFlow, ptr};
+use std::{marker::PhantomData, ops::ControlFlow, ptr};
 
 use dolang_bytecode::Variadic;
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt as _},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::{
         BoundMethod, dict,
@@ -460,9 +460,9 @@ fn debug<'v, 's>(
     module: &str,
     name: &str,
     strand: &mut Strand<'v, 's>,
-    w: &mut dyn fmt::Write,
+    w: &mut dyn crate::value::Format<'v>,
 ) -> Result<'v, 's, ()> {
-    write!(w, "<{module}.{name}>").into_do(strand)
+    crate::fmt!(strand, w, "<{module}.{name}>")
 }
 
 impl<'v> Protocol<'v> for View<'v> {
@@ -477,7 +477,7 @@ impl<'v> Protocol<'v> for View<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let view = this.borrow(strand)?;
         debug(view.glue.module(), view.glue.name(), strand, w)
@@ -621,9 +621,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<dictionary view iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<dictionary view iterator>")
     }
     async fn op_iter<'a, 's>(
         this: Recv<'v, 'a, Self>,

--- a/dolang-runtime/src/object/error.rs
+++ b/dolang-runtime/src/object/error.rs
@@ -9,7 +9,7 @@ use dolang_util::alias;
 
 use crate::{
     arg::Args,
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, Result},
     gc::{Collect, arena::Visit},
     strand::Strand,
     unpack,
@@ -168,17 +168,17 @@ impl<'v> Protocol<'v> for Boxed<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get()).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get())
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<error: {}>", this.get()).into_do(strand)
+        crate::fmt!(strand, w, "<error: {}>", this.get())
     }
 }
 
@@ -210,9 +210,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Error>").into_do(strand)
+        crate::fmt!(strand, w, "<type Error>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -272,9 +272,9 @@ impl<'v> Protocol<'v> for VariantType {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.error.{}>", variant_name(this.get().0)).into_do(strand)
+        crate::fmt!(strand, w, "<type std.error.{}>", variant_name(this.get().0))
     }
 
     fn op_inspect<'a>(this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/float.rs
+++ b/dolang-runtime/src/object/float.rs
@@ -1,10 +1,10 @@
-use std::{fmt, hash::DefaultHasher, ops::ControlFlow};
+use std::{hash::DefaultHasher, ops::ControlFlow};
 
 use dolang_util::alias;
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::{
         BoundMethod,
@@ -57,9 +57,9 @@ impl<'v> Protocol<'v> for f64 {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", *this.get()).into_do(strand)
+        crate::fmt!(strand, w, "{}", *this.get())
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &mut Strand<'v, 's>) -> bool {
@@ -230,25 +230,25 @@ impl<'v> Protocol<'v> for Verbatim {
     fn op_display_arg<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get().text).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get().text)
     }
 
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get().value).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get().value)
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{:?}", this.get().value).into_do(strand)
+        crate::fmt!(strand, w, "{:?}", this.get().value)
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &mut Strand<'v, 's>) -> bool {
@@ -411,9 +411,9 @@ impl<'v> Protocol<'v> for Float {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.float>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.float>")
     }
 
     async fn op_call<'a, 's>(

--- a/dolang-runtime/src/object/function.rs
+++ b/dolang-runtime/src/object/function.rs
@@ -1,11 +1,11 @@
-use std::{borrow::Cow, fmt, marker::PhantomData, ops::ControlFlow, ptr::NonNull};
+use std::{borrow::Cow, marker::PhantomData, ops::ControlFlow, ptr::NonNull};
 
 use dolang_util::alias;
 
 use crate::{
     Program,
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     frame::{CallFrame, Upvars},
     gc::{Collect, Gc, arena::Visit},
     strand::{Pinned, Strand},
@@ -157,19 +157,19 @@ impl<'v> Protocol<'v> for NativeFunction<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.get();
-        write!(w, "{}.{}", borrow.module, borrow.name).into_do(strand)
+        crate::fmt!(strand, w, "{}.{}", borrow.module, borrow.name)
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.get();
-        write!(w, "<{}.{}>", borrow.module, borrow.name).into_do(strand)
+        crate::fmt!(strand, w, "<{}.{}>", borrow.module, borrow.name)
     }
 
     async fn op_call<'a, 's>(
@@ -255,7 +255,7 @@ impl<'v> Protocol<'v> for Function<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.get();
         let module = borrow
@@ -269,23 +269,22 @@ impl<'v> Protocol<'v> for Function<'v> {
             .get(borrow.id)
             .map(|d| &borrow.module.debug_strtab()[d.name.clone()]);
         match (module, name) {
-            (None, None) => write!(w, "?.?"),
-            (None, Some(name)) => write!(w, "{name}"),
-            (Some(module), None) if borrow.id == 0 => write!(w, "{module}"),
-            (Some(module), None) => write!(w, "{module}.?"),
-            (Some(module), Some(name)) => write!(w, "{module}.{name}"),
+            (None, None) => crate::fmt!(strand, w, "?.?"),
+            (None, Some(name)) => crate::fmt!(strand, w, "{name}"),
+            (Some(module), None) if borrow.id == 0 => crate::fmt!(strand, w, "{module}"),
+            (Some(module), None) => crate::fmt!(strand, w, "{module}.?"),
+            (Some(module), Some(name)) => crate::fmt!(strand, w, "{module}.{name}"),
         }
-        .into_do(strand)
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<").into_do(strand)?;
+        crate::fmt!(strand, w, "<")?;
         Self::op_display(this, strand, w)?;
-        write!(w, ">").into_do(strand)
+        crate::fmt!(strand, w, ">")
     }
 }
 
@@ -317,10 +316,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        use crate::error::ResultExt;
-        write!(w, "<type std.func>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.func>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/int.rs
+++ b/dolang-runtime/src/object/int.rs
@@ -1,10 +1,10 @@
-use std::{fmt, hash::DefaultHasher, num::IntErrorKind, ops::ControlFlow};
+use std::{hash::DefaultHasher, num::IntErrorKind, ops::ControlFlow};
 
 use dolang_util::alias;
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::{
         BoundMethod,
@@ -65,9 +65,9 @@ impl<'v> Protocol<'v> for i128 {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", *this.get()).into_do(strand)
+        crate::fmt!(strand, w, "{}", *this.get())
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &mut Strand<'v, 's>) -> bool {
@@ -280,26 +280,26 @@ impl<'v> Protocol<'v> for Verbatim {
     fn op_display_arg<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get().text).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get().text)
     }
 
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get().value).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get().value)
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.get();
-        write!(w, "{}", borrow.text).into_do(strand)
+        crate::fmt!(strand, w, "{}", borrow.text)
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &mut Strand<'v, 's>) -> bool {
@@ -518,9 +518,9 @@ impl<'v> Protocol<'v> for Int {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.int>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.int>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/iter.rs
+++ b/dolang-runtime/src/object/iter.rs
@@ -1,10 +1,10 @@
-use std::{cell::UnsafeCell, fmt, ops::ControlFlow};
+use std::{cell::UnsafeCell, ops::ControlFlow};
 
 use crate::{
     arg::{Arg, Args},
     bytecode::Variadic,
     call,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Annex, Collect, arena::Visit},
     object::{
         BoundMethod,
@@ -407,9 +407,9 @@ impl<'v> Protocol<'v> for Iterable {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Iterable>").into_do(strand)
+        crate::fmt!(strand, w, "<type Iterable>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -478,9 +478,9 @@ impl<'v> Protocol<'v> for Sinkable {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Sinkable>").into_do(strand)
+        crate::fmt!(strand, w, "<type Sinkable>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -690,9 +690,9 @@ impl<'v> Protocol<'v> for Chain<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Chain>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Chain>")
     }
 
     async fn op_iter<'a, 's>(
@@ -756,9 +756,9 @@ impl<'v> Protocol<'v> for Zip<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Zip>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Zip>")
     }
 
     async fn op_iter<'a, 's>(
@@ -910,9 +910,9 @@ impl<'v> Protocol<'v> for Take<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Take>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Take>")
     }
 
     async fn op_iter<'a, 's>(
@@ -975,9 +975,9 @@ impl<'v> Protocol<'v> for Skip<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Skip>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Skip>")
     }
 
     async fn op_iter<'a, 's>(
@@ -1049,9 +1049,9 @@ impl<'v> Protocol<'v> for Enumerate<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Enumerate>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Enumerate>")
     }
 
     async fn op_iter<'a, 's>(
@@ -1122,9 +1122,9 @@ impl<'v> Protocol<'v> for Kv<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Kv>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Kv>")
     }
 
     async fn op_iter<'a, 's>(
@@ -1227,9 +1227,9 @@ impl<'v> Protocol<'v> for Iter {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Iter>").into_do(strand)
+        crate::fmt!(strand, w, "<type Iter>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -1372,9 +1372,9 @@ impl<'v> Protocol<'v> for Sink {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type Sink>").into_do(strand)
+        crate::fmt!(strand, w, "<type Sink>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {
@@ -1494,9 +1494,9 @@ impl<'v> Protocol<'v> for Map<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Map>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Map>")
     }
 
     async fn op_iter<'a, 's>(
@@ -1660,9 +1660,9 @@ impl<'v> Protocol<'v> for Filter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.iter.Filter>").into_do(strand)
+        crate::fmt!(strand, w, "<std.iter.Filter>")
     }
 
     async fn op_iter<'a, 's>(
@@ -1804,9 +1804,9 @@ impl<'v> Protocol<'v> for MapType {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.iter.Map>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.iter.Map>")
     }
 
     async fn op_call<'a, 's>(
@@ -1846,9 +1846,9 @@ impl<'v> Protocol<'v> for FilterType {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.iter.Filter>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.iter.Filter>")
     }
 
     async fn op_call<'a, 's>(
@@ -2019,9 +2019,9 @@ impl<'v> Protocol<'v> for Null {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<std.NullIter>").into_do(strand)
+        crate::fmt!(strand, w, "<std.NullIter>")
     }
 
     // Iter protocol: never yields any items

--- a/dolang-runtime/src/object/kv.rs
+++ b/dolang-runtime/src/object/kv.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::{Cell, RefCell},
-    fmt,
     hash::{DefaultHasher, Hash, Hasher},
     mem,
     ops::ControlFlow,
@@ -11,7 +10,7 @@ use bitvec::boxed::BitBox;
 use crate::{
     bytecode::Variadic,
     call,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     sig::{self, UnpackKeyKind},
     strand::Strand,
@@ -577,9 +576,9 @@ impl<'v, T: AsRef<Inner<'v>> + Collect + 'v> Protocol<'v> for Values<'v, T> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<values iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<values iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -663,9 +662,9 @@ impl<'v, T: AsRef<Inner<'v>> + Collect + 'v> Protocol<'v> for KeyValues<'v, T> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<key values iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<key values iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -757,9 +756,9 @@ impl<'v, T: AsRef<Inner<'v>> + Collect + 'v> Protocol<'v> for Keys<'v, T> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<keys iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<keys iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -852,13 +851,13 @@ impl<'v> Inner<'v> {
     pub(crate) fn op_debug<'a, 's, T: AsRef<Inner<'v>> + Collect + 'v>(
         this: Recv<'v, 'a, T>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
         open: &str,
         close: &str,
         separator: &str,
     ) -> Result<'v, 's, ()> {
         let this_borrow = this.borrow(strand)?;
-        write!(w, "{open}").into_do(strand)?;
+        crate::fmt!(strand, w, "{open}")?;
         let mut index = 0usize;
         let mut next_int_key = Some(0);
         let mut first = true;
@@ -876,7 +875,7 @@ impl<'v> Inner<'v> {
                 if first {
                     first = false
                 } else {
-                    write!(w, "{separator}").into_do(strand)?;
+                    crate::fmt!(strand, w, "{separator}")?;
                 }
                 if let (Some(int_key), Some(expected)) =
                     (bucket.as_ref().key.to_i64(strand).ok(), next_int_key)
@@ -890,15 +889,15 @@ impl<'v> Inner<'v> {
                     }
                 }
                 if let Some(sym) = bucket.as_ref().key.downcast_ref(strand.builtin_types().sym) {
-                    write!(w, "{}", sym.get().name).into_do(strand)?;
+                    crate::fmt!(strand, w, "{}", sym.get().name)?;
                 } else {
                     bucket.as_ref().key.op_debug(strand, w)?;
                 }
-                write!(w, ": ").into_do(strand)?;
+                crate::fmt!(strand, w, ": ")?;
                 bucket.as_ref().value.at(subindex).op_debug(strand, w)?;
             }
         }
-        write!(w, "{close}").into_do(strand)
+        crate::fmt!(strand, w, "{close}")
     }
 
     pub(crate) fn op_hash<'a, 's, T: AsRef<Inner<'v>> + Collect + 'v>(

--- a/dolang-runtime/src/object/mod.rs
+++ b/dolang-runtime/src/object/mod.rs
@@ -26,11 +26,11 @@ pub(crate) mod sym;
 pub(crate) mod tuple;
 pub(crate) mod types;
 
-use std::{fmt, ops::ControlFlow, ptr::NonNull};
+use std::{ops::ControlFlow, ptr::NonNull};
 
 use crate::{
     arg::Args,
-    error::{ErrorKind, Result, ResultExt},
+    error::{ErrorKind, Result},
     gc::{self, Collect, arena::Visit},
     object::protocol::Recv,
     strand::Strand,
@@ -522,12 +522,12 @@ impl<'v> Protocol<'v> for BoundMethod<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let me = this.receiver.get();
-        write!(w, "<bound method: {} receiver: ", me.method.name).into_do(strand)?;
+        crate::fmt!(strand, w, "<bound method: {} receiver: ", me.method.name)?;
         me.rcvr.op_debug(strand, w)?;
-        write!(w, ">").into_do(strand)
+        crate::fmt!(strand, w, ">")
     }
 
     async fn op_call<'a, 's>(

--- a/dolang-runtime/src/object/module.rs
+++ b/dolang-runtime/src/object/module.rs
@@ -1,11 +1,11 @@
-use std::{borrow::Cow, fmt, mem, ops::ControlFlow};
+use std::{borrow::Cow, mem, ops::ControlFlow};
 
 use dolang_util::alias;
 
 use crate::{
     Program,
     arg::Args,
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, Result},
     frame::Upvars,
     gc::{Collect, Gc, arena::Visit},
     object::{
@@ -102,7 +102,7 @@ impl<'v> Protocol<'v> for Module<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.get();
         let name = borrow
@@ -111,17 +111,17 @@ impl<'v> Protocol<'v> for Module<'v> {
             .as_ref()
             .map(|r| &borrow.loaded.debug_strtab()[r.clone()])
             .unwrap_or("?");
-        write!(w, "{name}").into_do(strand)
+        crate::fmt!(strand, w, "{name}")
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<").into_do(strand)?;
+        crate::fmt!(strand, w, "<")?;
         Self::op_display(this, strand, w)?;
-        write!(w, ">").into_do(strand)
+        crate::fmt!(strand, w, ">")
     }
 
     fn op_get<'a, 's>(
@@ -220,9 +220,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<module iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<module iterator>")
     }
 
     async fn op_next<'a, 's>(
@@ -318,19 +318,19 @@ impl<'v> Protocol<'v> for Native<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get().name).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get().name)
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<").into_do(strand)?;
+        crate::fmt!(strand, w, "<")?;
         Self::op_display(this, strand, w)?;
-        write!(w, ">").into_do(strand)
+        crate::fmt!(strand, w, ">")
     }
 
     fn op_get<'a, 's>(
@@ -480,7 +480,7 @@ impl<'v> Protocol<'v> for Namespace<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.borrow(strand)?;
         match &borrow.inner {
@@ -491,21 +491,21 @@ impl<'v> Protocol<'v> for Namespace<'v> {
                     .as_ref()
                     .map(|r| &module.loaded.debug_strtab()[r.clone()])
                     .unwrap_or("?");
-                write!(w, "{name}").into_do(strand)
+                crate::fmt!(strand, w, "{name}")
             }
             NamespaceInner::Custom(value) => value.op_display(strand, w),
-            NamespaceInner::Empty => write!(w, "namespace").into_do(strand),
+            NamespaceInner::Empty => crate::fmt!(strand, w, "namespace"),
         }
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<").into_do(strand)?;
+        crate::fmt!(strand, w, "<")?;
         Self::op_display(this, strand, w)?;
-        write!(w, ">").into_do(strand)
+        crate::fmt!(strand, w, ">")
     }
 
     fn op_get<'a, 's>(
@@ -631,9 +631,8 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        use crate::error::ResultExt;
-        write!(w, "<type std.module>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.module>")
     }
 }

--- a/dolang-runtime/src/object/native.rs
+++ b/dolang-runtime/src/object/native.rs
@@ -1,7 +1,7 @@
 use std::{
     borrow::Cow,
     cell::UnsafeCell,
-    fmt, future,
+    future,
     hash::Hasher,
     marker::PhantomData,
     mem::ManuallyDrop,
@@ -11,7 +11,7 @@ use std::{
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{
         self, Base, Collect,
         arena::{self, Upcast, Visit},
@@ -587,7 +587,7 @@ pub trait Object<'v>: Sized + 'v {
     fn display_arg<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::display(this, strand, w)
     }
@@ -596,7 +596,7 @@ pub trait Object<'v>: Sized + 'v {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::debug(this, strand, w)
     }
@@ -607,10 +607,10 @@ pub trait Object<'v>: Sized + 'v {
     fn debug<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let _ = this;
-        write!(w, "<{}.{}>", Self::MODULE, Self::NAME).into_do(strand)
+        crate::fmt!(strand, w, "<{}.{}>", Self::MODULE, Self::NAME)
     }
 
     /// Implements Do call (`func arg...`) operations.
@@ -1256,7 +1256,7 @@ impl<'v, T: Object<'v>> Protocol<'v> for ObjectWrap<'v, T> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Strand::for_native_frame(
             strand,
@@ -1270,7 +1270,7 @@ impl<'v, T: Object<'v>> Protocol<'v> for ObjectWrap<'v, T> {
     fn op_display_arg<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Strand::for_native_frame(
             strand,
@@ -1284,7 +1284,7 @@ impl<'v, T: Object<'v>> Protocol<'v> for ObjectWrap<'v, T> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Strand::for_native_frame(
             strand,
@@ -3038,9 +3038,9 @@ impl<'v, T: Object<'v>> Protocol<'v> for TypeObjectWrap<'v, T> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type: {}.{}>", T::MODULE, T::NAME).into_do(strand)
+        crate::fmt!(strand, w, "<type: {}.{}>", T::MODULE, T::NAME)
     }
 
     fn op_inspect<'a>(this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/protocol.rs
+++ b/dolang-runtime/src/object/protocol.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     hash::{DefaultHasher, Hasher},
     marker::PhantomData,
     ptr::{self, NonNull},
@@ -173,7 +172,7 @@ pub(crate) trait Protocol<'v>: Boxable<Header> + Collect + 'v {
     fn op_display_arg<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::op_display(this, strand, w)
     }
@@ -181,7 +180,7 @@ pub(crate) trait Protocol<'v>: Boxable<Header> + Collect + 'v {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::op_debug(this, strand, w)
     }
@@ -189,7 +188,7 @@ pub(crate) trait Protocol<'v>: Boxable<Header> + Collect + 'v {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()>;
 
     fn op_bool<'a, 's>(_this: Recv<'v, 'a, Self>, _strand: &mut Strand<'v, 's>) -> bool {
@@ -620,7 +619,7 @@ pub(crate) struct Vtbl<'v> {
         this: NonNull<Header>,
         strand: &'a mut Strand<'v, 's>,
         op: FmtOp,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
         _: &'a &'v (),
     ) -> Result<'v, 's, ()>,
     op_bool: for<'a, 's> fn(
@@ -1021,7 +1020,7 @@ fn op_fmt_glue<'v, 'a, 's, T: ?Sized + Protocol<'v>>(
     this: NonNull<Header>,
     strand: &'a mut Strand<'v, 's>,
     op: FmtOp,
-    w: &mut dyn fmt::Write,
+    w: &mut dyn crate::value::Format<'v>,
     _: &'a &'v (),
 ) -> Result<'v, 's, ()> {
     unsafe {
@@ -1363,19 +1362,19 @@ pub(crate) trait Dispatch<'v, 'a> {
     fn op_display_arg<'s>(
         &self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()>;
 
     fn op_display<'s>(
         &self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()>;
 
     fn op_debug<'s>(
         &self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()>;
 
     fn op_bool<'s>(&self, strand: &'a mut Strand<'v, 's>) -> bool;
@@ -1638,7 +1637,7 @@ impl<'v, 'a, T: AsHeader> Dispatch<'v, 'a> for T {
     fn op_display_arg<'s>(
         &self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         unsafe { invoke!(self, op_fmt, strand, FmtOp::DisplayArg, w) }
     }
@@ -1646,7 +1645,7 @@ impl<'v, 'a, T: AsHeader> Dispatch<'v, 'a> for T {
     fn op_display<'s>(
         &self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         unsafe { invoke!(self, op_fmt, strand, FmtOp::Display, w) }
     }
@@ -1654,7 +1653,7 @@ impl<'v, 'a, T: AsHeader> Dispatch<'v, 'a> for T {
     fn op_debug<'s>(
         &self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         unsafe { invoke!(self, op_fmt, strand, FmtOp::Debug, w) }
     }
@@ -1985,12 +1984,14 @@ pub(crate) async fn dispatch_native_method<'v, 's>(
     };
     match method.tag() {
         sym::STR_METHOD => {
-            let s = this.to_string(strand)?;
-            Output::set(strand, out, s.as_str());
+            let mut format = crate::value::StrEmbryo::new();
+            this.display(strand, &mut format)?;
+            format.finish(strand, out);
         }
         sym::DBG_METHOD => {
-            let s = this.to_debug(strand)?;
-            Output::set(strand, out, s.as_str());
+            let mut format = crate::value::StrEmbryo::new();
+            this.debug(strand, &mut format)?;
+            format.finish(strand, out);
         }
         sym::BOOL_METHOD => {
             let b = this.op_bool(strand);

--- a/dolang-runtime/src/object/range.rs
+++ b/dolang-runtime/src/object/range.rs
@@ -1,8 +1,8 @@
-use std::{fmt, hash::DefaultHasher, ops::ControlFlow};
+use std::{hash::DefaultHasher, ops::ControlFlow};
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::{
         iter,
@@ -208,7 +208,7 @@ impl<'v> Protocol<'v> for Range<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::op_debug(this, strand, w)
     }
@@ -216,20 +216,20 @@ impl<'v> Protocol<'v> for Range<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let borrow = this.get();
-        write!(w, "<range start: ").into_do(strand)?;
+        crate::fmt!(strand, w, "<range start: ")?;
         borrow.start.op_debug(strand, &mut *w)?;
         if !borrow.end.is_nil() {
-            write!(w, ", end: ").into_do(strand)?;
+            crate::fmt!(strand, w, ", end: ")?;
             borrow.end.op_debug(strand, &mut *w)?;
         }
         if !borrow.step.is_nil() {
-            write!(w, ", step: ").into_do(strand)?;
+            crate::fmt!(strand, w, ", step: ")?;
             borrow.step.op_debug(strand, &mut *w)?;
         }
-        write!(w, ">").into_do(strand)
+        crate::fmt!(strand, w, ">")
     }
 
     fn op_eq<'a, 's>(
@@ -404,7 +404,7 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::op_debug(this, strand, w)
     }
@@ -412,9 +412,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<range iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<range iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -503,10 +503,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        use crate::error::ResultExt;
-        write!(w, "<type std.range>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.range>")
     }
 
     async fn op_call<'a, 's>(

--- a/dolang-runtime/src/object/record.rs
+++ b/dolang-runtime/src/object/record.rs
@@ -1,6 +1,5 @@
 use std::{
     cell::{Cell, RefCell},
-    fmt,
     hash::{DefaultHasher, Hasher},
     ops::ControlFlow,
 };
@@ -9,7 +8,7 @@ use bitvec::bitbox;
 
 use crate::{
     arg::{Arg, Args},
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     sig,
     strand::Strand,
@@ -123,9 +122,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<record iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<record iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -228,9 +227,9 @@ impl<'v> Protocol<'v> for Unpack<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<record unpack iter>").into_do(strand)
+        crate::fmt!(strand, w, "<record unpack iter>")
     }
 
     async fn op_iter<'a, 's>(
@@ -312,7 +311,7 @@ impl<'v> Protocol<'v> for Record<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         kv::Inner::op_debug(this, strand, w, "<record ", ">", " ")
     }
@@ -530,9 +529,9 @@ impl<'v> Protocol<'v> for Class {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.record>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.record>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/set.rs
+++ b/dolang-runtime/src/object/set.rs
@@ -1,13 +1,12 @@
 use std::{
     cell::Cell,
-    fmt,
     hash::{DefaultHasher, Hash, Hasher},
     ops::ControlFlow,
 };
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     strand::Strand,
     sym::{self, Sym},
@@ -325,9 +324,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<set iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<set iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -410,9 +409,9 @@ impl<'v> Protocol<'v> for Set<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "set([").into_do(strand)?;
+        crate::fmt!(strand, w, "set([")?;
         let borrow = this.borrow(strand)?;
         let mut first = true;
         unsafe {
@@ -421,13 +420,13 @@ impl<'v> Protocol<'v> for Set<'v> {
                     continue;
                 };
                 if !first {
-                    write!(w, ", ").into_do(strand)?;
+                    crate::fmt!(strand, w, ", ")?;
                 }
                 bucket.as_ref().value.op_debug(strand, w)?;
                 first = false;
             }
         }
-        write!(w, "])").into_do(strand)
+        crate::fmt!(strand, w, "])")
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, strand: &mut Strand<'v, 's>) -> bool {
@@ -786,9 +785,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.set>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.set>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/str.rs
+++ b/dolang-runtime/src/object/str.rs
@@ -1,5 +1,4 @@
 use std::{
-    fmt,
     hash::{DefaultHasher, Hash},
     ops::ControlFlow,
 };
@@ -7,14 +6,14 @@ use std::{
 use crate::{
     arg::Args,
     bytecode::Variadic,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::protocol::GcObj,
     sig,
     strand::Strand,
     sym::{self, Sym},
     unpack,
-    value::{self, Output, Slot, Slots, Value},
+    value::{self, Output, Slot, Slots, StrEmbryo, Value},
     vm::Vm,
 };
 
@@ -75,29 +74,28 @@ impl<'v> Protocol<'v> for str {
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.receiver.get()).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.receiver.get())
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "\"").into_do(strand)?;
+        crate::fmt!(strand, w, "\"")?;
         for char in this.receiver.get().chars() {
             match char {
-                '"' | '\\' | '$' => write!(w, "\\{char}"),
-                '\t' => write!(w, "\\t"),
-                '\r' => write!(w, "\\r"),
-                '\n' => write!(w, "\\n"),
-                '\0' => write!(w, "\0"),
-                _ => write!(w, "{char}"),
-            }
-            .into_do(strand)?
+                '"' | '\\' | '$' => crate::fmt!(strand, w, "\\{char}"),
+                '\t' => crate::fmt!(strand, w, "\\t"),
+                '\r' => crate::fmt!(strand, w, "\\r"),
+                '\n' => crate::fmt!(strand, w, "\\n"),
+                '\0' => crate::fmt!(strand, w, "\0"),
+                _ => crate::fmt!(strand, w, "{char}"),
+            }?
         }
-        write!(w, "\"").into_do(strand)
+        crate::fmt!(strand, w, "\"")
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &'a mut Strand<'v, 's>) -> bool {
@@ -159,7 +157,7 @@ impl<'v> Protocol<'v> for str {
         strand: &'a mut Strand<'v, 's>,
         method: Sym<'v, 'a>,
         args: Args<'v, 'a>,
-        mut out: Slot<'v, 'a>,
+        out: Slot<'v, 'a>,
     ) -> Result<'v, 's, ()> {
         let me = this.get();
 
@@ -293,16 +291,16 @@ impl<'v> Protocol<'v> for str {
                         } else {
                             strand.input(&mut input)
                         }
-                        let mut acc = String::new();
+                        let mut acc = StrEmbryo::new();
                         if input.next(strand, &mut value).await? {
                             value.op_display(strand, &mut acc)?;
                         }
                         while input.next(strand, &mut value).await? {
-                            acc.push_str(this.receiver.get());
+                            acc.extend(strand, this.receiver.get());
                             value.op_display(strand, &mut acc)?;
                             strand.check_trap_gc()?;
                         }
-                        out.store(Value::from_str(strand, &acc));
+                        acc.finish(strand, out);
                         Ok(())
                     })
                     .await
@@ -547,7 +545,7 @@ impl<'v> Protocol<'v> for Split<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let forward = this.borrow_mut(strand)?.forward;
         let label = if forward {
@@ -555,7 +553,7 @@ impl<'v> Protocol<'v> for Split<'v> {
         } else {
             "<str rsplit>"
         };
-        write!(w, "{label}").into_do(strand)
+        crate::fmt!(strand, w, "{label}")
     }
 
     async fn op_iter<'a, 's>(
@@ -681,9 +679,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.str>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.str>")
     }
 
     async fn op_call<'a, 's>(
@@ -694,8 +692,9 @@ impl<'v> Protocol<'v> for Type {
     ) -> Result<'v, 's, ()> {
         // Constructor: str(value) - convert to string
         let ([value], _) = unpack!(strand, args, 1, 0)?;
-        let str = value.to_string(strand)?;
-        Output::set(strand, out, str.as_str());
+        let mut format = StrEmbryo::new();
+        value.display(strand, &mut format)?;
+        format.finish(strand, out);
         Ok(())
     }
 
@@ -771,13 +770,15 @@ impl<'v> Protocol<'v> for Type {
         strand: &'a mut Strand<'v, 's>,
         method: Sym<'v, 'a>,
         args: Args<'v, 'a>,
-        out: Slot<'v, 'a>,
+        mut out: Slot<'v, 'a>,
     ) -> Result<'v, 's, ()> {
         match method.tag() {
             sym::INIT_METHOD => {
                 let ([self_val, value], []) = unpack!(strand, args, 2, 0)?;
-                let s = value.to_string(strand)?;
-                let native = Value::from_str(strand, s.as_str());
+                let mut format = StrEmbryo::new();
+                value.display(strand, &mut format)?;
+                format.finish(strand, &mut out);
+                let native = out.take();
                 self_val.op_fill(strand, &strand.singletons().str, native)?;
                 Ok(())
             }

--- a/dolang-runtime/src/object/strand.rs
+++ b/dolang-runtime/src/object/strand.rs
@@ -1,8 +1,8 @@
-use std::{fmt, future, ops::ControlFlow, rc::Rc, task::Poll, task::Waker};
+use std::{future, ops::ControlFlow, rc::Rc, task::Poll, task::Waker};
 
 use crate::{
     arg::Args,
-    error::{Error, ErrorPair, Result, ResultExt},
+    error::{Error, ErrorPair, Result},
     gc::{Collect, arena::Visit},
     method,
     strand::{InterruptToken, Strand, StrandInner},
@@ -122,15 +122,15 @@ impl<'v> Protocol<'v> for Handle<'v> {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
         let is_stream = !this.borrow(strand)?.stream_output.is_nil();
-        write!(
+        crate::fmt!(
+            strand,
             w,
             "<strand.{}>",
             if is_stream { "Stream" } else { "Strand" }
         )
-        .into_do(strand)
     }
 
     async fn op_mcall<'a, 's>(
@@ -310,9 +310,8 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        use crate::error::ResultExt;
-        write!(w, "<type strand.Strand>").into_do(strand)
+        crate::fmt!(strand, w, "<type strand.Strand>")
     }
 }

--- a/dolang-runtime/src/object/sym.rs
+++ b/dolang-runtime/src/object/sym.rs
@@ -1,12 +1,11 @@
 use std::{
-    fmt,
     hash::{DefaultHasher, Hash},
     ops::ControlFlow,
 };
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     strand::Strand,
     sym::Tag,
@@ -47,25 +46,25 @@ impl<'v> Protocol<'v> for SymObj {
     fn op_display_arg<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, ":{}:", this.get().name).into_do(strand)
+        crate::fmt!(strand, w, ":{}:", this.get().name)
     }
 
     fn op_display<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "{}", this.get().name).into_do(strand)
+        crate::fmt!(strand, w, "{}", this.get().name)
     }
 
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<sym {}>", this.get().name).into_do(strand)
+        crate::fmt!(strand, w, "<sym {}>", this.get().name)
     }
 
     fn op_eq<'a, 's>(
@@ -128,9 +127,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.sym>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.sym>")
     }
 
     async fn op_call<'a, 's>(

--- a/dolang-runtime/src/object/tuple.rs
+++ b/dolang-runtime/src/object/tuple.rs
@@ -1,10 +1,10 @@
-use std::{fmt, ops::ControlFlow};
+use std::ops::ControlFlow;
 
 use crate::{
     arg::Args,
     bytecode::Variadic,
     call,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{self, Collect, arena::Visit},
     object::protocol::{Protocol, Recv},
     sig::{Unpack, UnpackKeyKind},
@@ -90,18 +90,18 @@ impl<'v> Protocol<'v> for [Value<'v>] {
     fn op_debug<'a, 's>(
         this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "(").into_do(strand)?;
+        crate::fmt!(strand, w, "(")?;
         let mut iter = this.receiver.get().iter();
         if let Some(first) = iter.next() {
             first.op_debug(strand, w)?;
             for item in iter {
-                write!(w, ", ").into_do(strand)?;
+                crate::fmt!(strand, w, ", ")?;
                 item.op_debug(strand, w)?;
             }
         }
-        write!(w, ")").into_do(strand)
+        crate::fmt!(strand, w, ")")
     }
 
     fn op_bool<'a, 's>(this: Recv<'v, 'a, Self>, _strand: &mut Strand<'v, 's>) -> bool {
@@ -403,9 +403,9 @@ impl<'v> Protocol<'v> for Iter<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<tuple iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<tuple iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -506,9 +506,9 @@ impl<'v> Protocol<'v> for Pairs<'v> {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<tuple pair iterator>").into_do(strand)
+        crate::fmt!(strand, w, "<tuple pair iterator>")
     }
 
     async fn op_iter<'a, 's>(
@@ -704,10 +704,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        use crate::error::ResultExt;
-        write!(w, "<type std.tuple>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.tuple>")
     }
 
     fn op_inspect<'a>(_this: Recv<'v, 'a, Self>, _vm: &Vm<'v>) -> Option<Inspect<'v, 'a>> {

--- a/dolang-runtime/src/object/types.rs
+++ b/dolang-runtime/src/object/types.rs
@@ -1,10 +1,10 @@
 //! Builtin primitive type class objects
 
-use std::{fmt, ops::ControlFlow};
+use std::ops::ControlFlow;
 
 use crate::{
     arg::Args,
-    error::{Error, Result, ResultExt},
+    error::{Error, Result},
     gc::{Collect, arena::Visit},
     object::{
         BoundMethod,
@@ -44,9 +44,9 @@ impl<'v> Protocol<'v> for Value {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type value>").into_do(strand)
+        crate::fmt!(strand, w, "<type value>")
     }
 
     async fn op_call<'a, 's>(
@@ -93,9 +93,9 @@ impl<'v> Protocol<'v> for Type {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type>").into_do(strand)
+        crate::fmt!(strand, w, "<type>")
     }
 
     async fn op_call<'a, 's>(
@@ -169,9 +169,9 @@ impl<'v> Protocol<'v> for Bool {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.bool>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.bool>")
     }
 
     async fn op_call<'a, 's>(
@@ -273,9 +273,9 @@ impl<'v> Protocol<'v> for ArgsType {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.args>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.args>")
     }
 
     async fn op_call<'a, 's>(
@@ -305,8 +305,8 @@ impl<'v> Protocol<'v> for NilType {
     fn op_debug<'a, 's>(
         _this: Recv<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn crate::value::Format<'v>,
     ) -> Result<'v, 's, ()> {
-        write!(w, "<type std.Nil>").into_do(strand)
+        crate::fmt!(strand, w, "<type std.Nil>")
     }
 }

--- a/dolang-runtime/src/stdlib/mod.rs
+++ b/dolang-runtime/src/stdlib/mod.rs
@@ -1,6 +1,12 @@
 use std::hash::{DefaultHasher, Hasher};
 
-use crate::{arg::Arg, error::Error, unpack, value::Output, vm::Builder};
+use crate::{
+    arg::Arg,
+    error::Error,
+    unpack,
+    value::{Output, StrEmbryo},
+    vm::Builder,
+};
 
 mod property;
 mod strand;
@@ -125,14 +131,16 @@ pub(crate) fn configure<'v>(builder: &mut Builder<'v>) {
         // Core functions
         .function("arg", async move |strand, args, out| {
             let ([value], _) = unpack!(strand, args, 1, 0)?;
-            let str = value.to_arg(strand)?;
-            Output::set(strand, out, str.as_str());
+            let mut format = StrEmbryo::new();
+            value.display_arg(strand, &mut format)?;
+            format.finish(strand, out);
             Ok(())
         })
         .function("dbg", async move |strand, args, out| {
             let ([value], _) = unpack!(strand, args, 1, 0)?;
-            let debug = value.to_debug(strand)?;
-            Output::set(strand, out, debug.as_str());
+            let mut format = StrEmbryo::new();
+            value.debug(strand, &mut format)?;
+            format.finish(strand, out);
             Ok(())
         })
         .function("hash", async move |strand, args, out| {

--- a/dolang-runtime/src/value/mod.rs
+++ b/dolang-runtime/src/value/mod.rs
@@ -16,7 +16,7 @@ use std::{
 use crate::{
     Program,
     arg::Args,
-    error::{Error, ErrorKind, Result, ResultExt},
+    error::{Error, ErrorKind, Result},
     frame::{Frame, Upvars},
     gc::{self, Base, BaseBorrow, BaseWeak, Collect, Gc, arena},
     method,
@@ -67,6 +67,88 @@ pub struct BinEmbryo<'v> {
 /// caller can uphold that invariant manually.
 pub struct StrEmbryo<'v> {
     embryo: Option<gc::Embryo<'v, Header, [u8]>>,
+}
+
+/// Destination for formatting Do values.
+///
+/// This mirrors [`fmt::Write`], but supplies the active [`Strand`] to each
+/// operation and returns native Do errors so destinations may allocate
+/// GC-managed storage while data is appended.
+pub trait Format<'v> {
+    /// Appends a string slice to this destination.
+    fn write_str<'s>(&mut self, strand: &mut Strand<'v, 's>, s: &str) -> Result<'v, 's, ()>;
+
+    /// Appends a character to this destination.
+    fn write_char<'s>(&mut self, strand: &mut Strand<'v, 's>, c: char) -> Result<'v, 's, ()> {
+        let mut buf = [0; 4];
+        self.write_str(strand, c.encode_utf8(&mut buf))
+    }
+
+    /// Writes formatted data to this destination.
+    fn write_fmt<'s>(
+        &mut self,
+        strand: &mut Strand<'v, 's>,
+        args: fmt::Arguments<'_>,
+    ) -> Result<'v, 's, ()> {
+        let mut writer = FormatWrite::new(self, strand);
+        let result = fmt::write(&mut writer, args);
+        let error = writer.error.take();
+        drop(writer);
+        match result {
+            Ok(()) => Ok(()),
+            Err(err) => Err(error.unwrap_or_else(|| Error::runtime(strand, err))),
+        }
+    }
+}
+
+struct FormatWrite<'v, 's, 'a, F: ?Sized> {
+    format: &'a mut F,
+    strand: &'a mut Strand<'v, 's>,
+    error: Option<Error<'v, 's>>,
+}
+
+impl<'v, 's, 'a, F: ?Sized> FormatWrite<'v, 's, 'a, F> {
+    fn new(format: &'a mut F, strand: &'a mut Strand<'v, 's>) -> Self {
+        Self {
+            format,
+            strand,
+            error: None,
+        }
+    }
+}
+
+impl<'v, F: Format<'v> + ?Sized> fmt::Write for FormatWrite<'v, '_, '_, F> {
+    fn write_str(&mut self, s: &str) -> fmt::Result {
+        self.format.write_str(self.strand, s).map_err(|error| {
+            self.error = Some(error);
+            fmt::Error
+        })
+    }
+
+    fn write_char(&mut self, c: char) -> fmt::Result {
+        self.format.write_char(self.strand, c).map_err(|error| {
+            self.error = Some(error);
+            fmt::Error
+        })
+    }
+}
+
+impl<'v, W: fmt::Write + ?Sized> Format<'v> for W {
+    fn write_str<'s>(&mut self, strand: &mut Strand<'v, 's>, s: &str) -> Result<'v, 's, ()> {
+        fmt::Write::write_str(self, s).map_err(|err| Error::runtime(strand, err))
+    }
+
+    fn write_char<'s>(&mut self, strand: &mut Strand<'v, 's>, c: char) -> Result<'v, 's, ()> {
+        fmt::Write::write_char(self, c).map_err(|err| Error::runtime(strand, err))
+    }
+
+    fn write_fmt<'s>(
+        &mut self,
+        strand: &mut Strand<'v, 's>,
+        args: fmt::Arguments<'_>,
+    ) -> Result<'v, 's, ()> {
+        fmt::Write::write_fmt(self, args).map_err(|err| Error::runtime(strand, err))
+    }
 }
 
 unsafe impl<'v> Collect for Value<'v> {
@@ -358,10 +440,10 @@ impl<'v> Value<'v> {
     pub(crate) fn op_display_arg<'a, 's>(
         &'a self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn Format<'v>,
     ) -> Result<'v, 's, ()> {
         match self.case() {
-            Case::Prim(prim) => write!(w, "{}", prim).into_do(strand),
+            Case::Prim(prim) => crate::fmt!(strand, w, "{}", prim),
             Case::Object(o) => o.op_display_arg(strand, w),
         }
     }
@@ -369,10 +451,10 @@ impl<'v> Value<'v> {
     pub(crate) fn op_display<'a, 's>(
         &'a self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn Format<'v>,
     ) -> Result<'v, 's, ()> {
         match self.case() {
-            Case::Prim(prim) => write!(w, "{}", prim).into_do(strand),
+            Case::Prim(prim) => crate::fmt!(strand, w, "{}", prim),
             Case::Object(o) => o.op_display(strand, w),
         }
     }
@@ -422,10 +504,10 @@ impl<'v> Value<'v> {
     pub(crate) fn op_debug<'a, 's>(
         &'a self,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn Format<'v>,
     ) -> Result<'v, 's, ()> {
         match self.case() {
-            Case::Prim(prim) => write!(w, "{}", prim).into_do(strand),
+            Case::Prim(prim) => crate::fmt!(strand, w, "{}", prim),
             Case::Object(o) => o.op_debug(strand, w),
         }
     }
@@ -1004,12 +1086,42 @@ impl<'v> Value<'v> {
         self.to_prim(strand)?.to_index(strand)
     }
 
+    /// Writes the command-line argument representation of this value to `format`.
+    #[inline]
+    pub fn display_arg<'a, 's>(
+        &'a self,
+        strand: &'a mut Strand<'v, 's>,
+        format: &mut dyn Format<'v>,
+    ) -> Result<'v, 's, ()> {
+        self.op_display_arg(strand, format)
+    }
+
+    /// Writes the human-readable representation of this value to `format`.
+    #[inline]
+    pub fn display<'a, 's>(
+        &'a self,
+        strand: &'a mut Strand<'v, 's>,
+        format: &mut dyn Format<'v>,
+    ) -> Result<'v, 's, ()> {
+        self.op_display(strand, format)
+    }
+
+    /// Writes the debug representation of this value to `format`.
+    #[inline]
+    pub fn debug<'a, 's>(
+        &'a self,
+        strand: &'a mut Strand<'v, 's>,
+        format: &mut dyn Format<'v>,
+    ) -> Result<'v, 's, ()> {
+        self.op_debug(strand, format)
+    }
+
     /// Convert value to command-line argument string.
     /// See the documentation for `std.arg` in the language documentation for details.
     #[inline]
     pub fn to_arg<'a, 's>(&'a self, strand: &'a mut Strand<'v, 's>) -> Result<'v, 's, String> {
         let mut out = String::new();
-        self.op_display_arg(strand, &mut out)?;
+        self.display_arg(strand, &mut out)?;
         Ok(out)
     }
 
@@ -1017,7 +1129,7 @@ impl<'v> Value<'v> {
     #[inline]
     pub fn to_string<'a, 's>(&'a self, strand: &'a mut Strand<'v, 's>) -> Result<'v, 's, String> {
         let mut out = String::new();
-        self.op_display(strand, &mut out)?;
+        self.display(strand, &mut out)?;
         Ok(out)
     }
 
@@ -1025,7 +1137,7 @@ impl<'v> Value<'v> {
     #[inline]
     pub fn to_debug<'a, 's>(&'a self, strand: &'a mut Strand<'v, 's>) -> Result<'v, 's, String> {
         let mut out = String::new();
-        self.op_debug(strand, &mut out)?;
+        self.debug(strand, &mut out)?;
         Ok(out)
     }
 
@@ -1707,6 +1819,13 @@ impl<'v> StrEmbryo<'v> {
             }
         };
         Slot::from_output(&mut out).store(value)
+    }
+}
+
+impl<'v> Format<'v> for StrEmbryo<'v> {
+    fn write_str<'s>(&mut self, strand: &mut Strand<'v, 's>, s: &str) -> Result<'v, 's, ()> {
+        self.extend(strand, s);
+        Ok(())
     }
 }
 

--- a/dolang-shell-core/src/interactive.rs
+++ b/dolang-shell-core/src/interactive.rs
@@ -1,10 +1,4 @@
-use std::{
-    borrow::Cow,
-    fmt::{self, Write},
-    ops::ControlFlow,
-    path::Path,
-    string::String,
-};
+use std::{borrow::Cow, fmt::Write, ops::ControlFlow, path::Path, string::String};
 
 use dolang::{
     compile::{Context, Diag, Mode, Origin, Span, Token},
@@ -48,7 +42,7 @@ impl<'v> Object<'v> for DynamicPrelude<'v> {
     fn display<'a, 's>(
         this: Instance<'v, 'a, Self>,
         strand: &'a mut Strand<'v, 's>,
-        w: &mut dyn fmt::Write,
+        w: &mut dyn dolang::runtime::Format<'v>,
     ) -> Result<'v, 's, ()> {
         Self::debug(this, strand, w)
     }

--- a/dolang/src/runtime.rs
+++ b/dolang/src/runtime.rs
@@ -8,7 +8,7 @@ pub use dolang_runtime::{
 /// Value manipulation
 pub mod value {
     pub use dolang_runtime::value::{
-        AsTuple, BinEmbryo, Empty, Input, Nil, Output, Root, Singleton, Slot, StrEmbryo,
+        AsTuple, BinEmbryo, Empty, Format, Input, Nil, Output, Root, Singleton, Slot, StrEmbryo,
         TypeObject, Value,
         view::{
             Array, Bin, Dict, DictPairs, ObjectId, ObjectView, PinBin, PinStr, Record, RecordPairs,
@@ -17,7 +17,7 @@ pub mod value {
     };
 }
 
-pub use value::{Input, Output, Slot, Value};
+pub use value::{Format, Input, Output, Slot, Value};
 
 /// Error handling
 pub mod error {
@@ -38,6 +38,7 @@ pub mod object {
         array_view::{ArrayLike, ArrayView},
         dict_view::{DictLike, DictView, DictViewSink},
     };
+    pub use dolang_runtime::{fmt, value::Format};
 }
 
 pub use object::{Instance, Object, Type};

--- a/test/proc/run.dol
+++ b/test/proc/run.dol
@@ -26,6 +26,12 @@ import agent proc sys
 
 let is_windows = (sys.os_info().family == :WINDOWS:)
 
+class Rendered
+  pub field value = "rendered"
+
+  def (str) self
+    self.value
+
 def yield()
   sleep 0.01
 
@@ -130,6 +136,19 @@ def pipe_send_side_value_flush()
       yield()
       cat()
   assert_eq $res "foo\nfoo"
+
+#[agent.test]
+def formatted_values_stream_to_capture_and_pipe()
+  if is_windows
+    skip "windows polyfill not yet adequate"
+
+  let res = sub do strand.put (Rendered())
+  assert_eq $res rendered
+
+  res = sub do pipeline
+    do strand.put (Rendered())
+    do cat()
+  assert_eq $res rendered
 
 #[agent.test]
 def pipeline_and_io_mode_use_matching_encodings()


### PR DESCRIPTION
This allows passing through the `Strand`, allowing the impl to GC allocate.  This allows formatting directly into GC memory with `StrEmbryo`.

Closes issue #128 