### PR TITLE
Explicitly release file locks on close

### DIFF
--- a/dolang-shell-vfs/src/direct/lock.rs
+++ b/dolang-shell-vfs/src/direct/lock.rs
@@ -68,6 +68,37 @@ impl DirectFileLocks {
         };
         reservation.commit(armed).map(Some)
     }
+
+    /// Releases every lock still held on this file, in band.
+    ///
+    /// Closing a descriptor only drops the underlying locks once *every*
+    /// duplicate of the open file description is gone, and duplicates outlive
+    /// this file for all sorts of reasons — they are handed to other processes
+    /// over the wire, held by in-flight blocking work, and so on — so an
+    /// explicit unlock is the only reliable release. Callers must do this
+    /// before dropping the file's handles.
+    pub(crate) async fn release_all(&self) -> io::Result<()> {
+        let Some(table) = self.table.get() else {
+            return Ok(());
+        };
+        let armed = table.take_all_armed();
+        if armed.is_empty() {
+            return Ok(());
+        }
+        tokio::task::spawn_blocking(move || {
+            let mut outcome = Ok(());
+            for lock in armed {
+                if let Err(error) = lock.release()
+                    && outcome.is_ok()
+                {
+                    outcome = Err(error);
+                }
+            }
+            outcome
+        })
+        .await
+        .map_err(|_| io::Error::other("file unlock worker failed"))?
+    }
 }
 
 #[derive(Debug)]
@@ -180,6 +211,21 @@ impl LockTable {
         self.state.lock().unwrap().entries.remove(&id);
     }
 
+    fn take_all_armed(&self) -> Vec<ArmedLock> {
+        let mut state = self.state.lock().unwrap();
+        let mut armed = Vec::new();
+        state.entries.retain(|_, entry| match entry.armed.take() {
+            Some(lock) => {
+                armed.push(lock);
+                false
+            }
+            // A reservation that has not committed yet, or a release already in
+            // progress elsewhere; neither is ours to take.
+            None => true,
+        });
+        armed
+    }
+
     fn take_armed(&self, id: u64) -> io::Result<Option<ArmedLock>> {
         let mut state = self.state.lock().unwrap();
         let Some(entry) = state.entries.get_mut(&id) else {
@@ -200,16 +246,6 @@ fn release(armed: ArmedLock, table: Weak<LockTable>, id: u64) -> io::Result<()> 
         table.remove(id);
     }
     outcome
-}
-
-impl Drop for LockTable {
-    fn drop(&mut self) {
-        for entry in self.state.get_mut().unwrap().entries.values_mut() {
-            if let Some(armed) = &mut entry.armed {
-                armed.disarm();
-            }
-        }
-    }
 }
 
 struct Reservation {
@@ -264,10 +300,6 @@ impl ArmedLock {
             return Ok(());
         };
         unlock(&handle, self.range)
-    }
-
-    fn disarm(&mut self) {
-        self.handle.take();
     }
 }
 

--- a/dolang-shell-vfs/src/direct/mod.rs
+++ b/dolang-shell-vfs/src/direct/mod.rs
@@ -211,10 +211,14 @@ impl FileHandle for DirectFile {
 
     async fn close(mut self) -> crate::Result<()> {
         use tokio::io::AsyncWriteExt as _;
-        let result = self.inner.flush().await;
+        let result = self.inner.flush().await.map_err(crate::Error::from);
+        // Unlock in band rather than leaving it to the handles being closed:
+        // duplicates of this open file description may still be alive
+        // elsewhere, which would keep the locks in force past this point.
+        let released = self.locks.release_all().await.map_err(crate::Error::from);
         let file = self.inner;
         let _ = tokio::task::spawn_blocking(move || drop(file)).await;
-        result.map_err(Into::into)
+        result.and(released)
     }
 
     async fn set_size(&mut self, size: u64) -> crate::Result<()> {

--- a/dolang-shell-vfs/tests/direct.rs
+++ b/dolang-shell-vfs/tests/direct.rs
@@ -124,6 +124,49 @@ async fn byte_range_locks_contend_and_release() {
     );
 }
 
+// Whole-file locks work everywhere on Unix, FreeBSD's `flock` included, and
+// `to_stdio_send` duplicates the descriptor rather than reopening the file, so
+// the duplicate shares the lock on every one of these platforms.
+#[cfg(unix)]
+#[tokio::test]
+async fn closing_a_file_releases_locks_held_by_duplicate_handles() {
+    let direct = Direct::default();
+    let dir = tempdir().unwrap();
+    let path = dir.path().join("closed-locks");
+    let first = open_lock_file(&direct, &path).await;
+    let second = open_lock_file(&direct, &path).await;
+
+    let mut held = first
+        .lock(lock_request(
+            0,
+            None,
+            FileLockMode::Exclusive,
+            FileLockBehavior::Blocking,
+        ))
+        .await
+        .unwrap()
+        .unwrap();
+    // A duplicate of the same open file description outlives the close, so the
+    // lock stays in force unless the close unlocks explicitly.
+    let duplicate = first.to_stdio_send().await.unwrap();
+    first.close().await.unwrap();
+
+    assert!(
+        second
+            .lock(lock_request(
+                0,
+                None,
+                FileLockMode::Exclusive,
+                FileLockBehavior::Try,
+            ))
+            .await
+            .unwrap()
+            .is_some()
+    );
+    held.release().await.unwrap();
+    drop(duplicate);
+}
+
 #[cfg(target_os = "freebsd")]
 #[tokio::test]
 async fn byte_range_locks_are_rejected() {


### PR DESCRIPTION
This prevents incidental file handle duplicates from inhibiting in-band unlock.