### PR TITLE
Fix order inversion in future pinning arena

### DIFF
--- a/dolang-private-util/src/pin.rs
+++ b/dolang-private-util/src/pin.rs
@@ -157,6 +157,9 @@ impl Arena {
         unsafe {
             let last_seg = entry.as_ref().last_seg;
             let last_cur = entry.as_ref().last_cur;
+            // Must drop contents *first*, which drops any nested Pinned guard;
+            // segment/offset updates will then occur in LIFO order as required
+            ptr::drop_in_place(entry.as_ptr());
             while self.seg.get() != last_seg {
                 self.seg.update(|seg| {
                     let prev = (*seg.as_ptr()).prev.unwrap_unchecked();
@@ -165,7 +168,6 @@ impl Arena {
                 })
             }
             (*self.seg.get().as_ptr()).cur.set(last_cur);
-            ptr::drop_in_place(entry.as_ptr());
         }
     }
 


### PR DESCRIPTION
When a panic unwinds a future chain which is being polled, any Pinned guards owned by the state machine drop in LIFO order as required. However, if the top-level future is simply dropped because of panic not originating in nested poll calls, the outermost Pinned is dropped first.  Therefore, the contents (and thus the next nested Pinned) must be dropped before adjusting arena segments or offsets so that they occur in LIFO order.