### PR TITLE
Refactor RPC handles

### DIFF
--- a/dolang-rpc/ARCHITECTURE.md
+++ b/dolang-rpc/ARCHITECTURE.md
@@ -437,28 +437,22 @@ local attachment-capable sessions.
 ## Serialization Context
 
 Direct handles require per-frame state while values are serialized and
-deserialized. The crate passes this state explicitly through wrapper
-`Serializer` and `Deserializer` implementations and serde seeds. The wrappers
-use transactional handle contexts supplied by the transport; application
-payload types never access the transport directly.
+deserialized. The crate installs the transport context in scoped thread-local
+storage around each synchronous postcard call. `Opaque` and `OsHandle` access
+that context directly from their serde implementations. A swap guard restores
+the previous context after normal return or unwinding, so nested serialization
+uses the innermost context. Using either type through serde outside an RPC
+session panics.
 
-Serialization obtains the transport's associated `Send` value. Serializing an
-`OsHandle` calls the platform-appropriate attachment method, which stages or
-copies the native handle and returns its wire representation. Unix descriptor
+Serializing an `OsHandle` transfers its owned handle into the transport context
+immediately and writes the returned wire representation. Unix descriptor
 attachment returns a queue index. Windows handle attachment returns the actual
-peer-local `HANDLE` value at pointer width. A self-by-value finishing method
-takes the complete header-and-payload buffer and sends it with all staged
-handles. Dropping a Unix `Send` before finishing clears its staged descriptors.
-Windows server-to-client duplication is immediate. The send frame records each
-peer-local result and makes a best-effort attempt to close them if the frame is
-dropped during serialization; once transmission starts, delivery is ambiguous
-and cleanup is deliberately disarmed.
-
-Unix `Send` retains `BorrowedFd`s for its full lifetime rather than duplicating
-them. Requests and responses are therefore moved to the writer task and kept
-alive until the consuming send operation completes. The contextual serializer
-is the only unsafe bridge from serde's erased raw descriptor representation to
-the frame lifetime.
+peer-local `HANDLE` value at pointer width. Serializing the same `OsHandle`
+again fails because it has already been emptied. Outgoing messages are owned by
+the RPC writer and discarded on serialization failure; the state of such a
+failed message is not part of the API contract. Windows server-to-client
+duplication is immediate, while Unix retains the stolen descriptors until
+attachment.
 
 The transport accumulates received native handles internally as reads
 complete. The receive loop obtains an associated `RecvFrame` value before

--- a/dolang-rpc/src/client.rs
+++ b/dolang-rpc/src/client.rs
@@ -21,14 +21,20 @@ use std::{
 #[cfg(windows)]
 use windows_sys::Win32::System::Threading::GetProcessId;
 
-#[cfg(windows)]
-use crate::handle::TakeHandle;
+#[cfg(unix)]
+use crate::session::SessionHandles;
 use crate::{
     Error, Limits, Protocol,
     fragment::{self, AbortOutcome, Event, Kind, Message, Reassembler, Scheduler, Trailer},
     serde::{decode_payload, encode_payload},
+    session::{Ledger, Session, SessionFrame},
     trailer::{RecvShared, SendShared, TrailerRecv, TrailerSend},
     transport::{self, EncodeHandles, Receiver, Sender},
+};
+#[cfg(windows)]
+use crate::{
+    handle::TakeHandle,
+    session::{Ref, Session},
 };
 
 /// A negotiated client endpoint that has not yet been bound to a [`Protocol`].
@@ -40,25 +46,27 @@ pub use crate::unbound::UnboundClient as Unbound;
 type Pending<R> = HashMap<u64, oneshot::Sender<Result<CallResult<R>, Error>>>;
 
 #[cfg(windows)]
-struct DecodeHandles {
+struct DecodeHandles<'a> {
     consumed: HashSet<usize>,
     count: usize,
     max_handles: usize,
+    session: &'a Arc<Session>,
 }
 
 #[cfg(windows)]
-impl DecodeHandles {
-    fn new(max_handles: usize) -> Self {
+impl<'a> DecodeHandles<'a> {
+    fn new(max_handles: usize, session: &'a Arc<Session>) -> Self {
         Self {
             consumed: HashSet::new(),
             count: 0,
             max_handles,
+            session,
         }
     }
 }
 
 #[cfg(windows)]
-impl TakeHandle for DecodeHandles {
+impl TakeHandle for DecodeHandles<'_> {
     fn take_handle(&mut self, value: usize) -> io::Result<OwnedHandle> {
         if !self.consumed.insert(value) {
             return Err(io::Error::new(
@@ -80,6 +88,12 @@ impl TakeHandle for DecodeHandles {
             ));
         }
         Ok(())
+    }
+
+    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<Ref> {
+        self.session
+            .take(owner, id)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
     }
 }
 
@@ -115,13 +129,30 @@ enum Outgoing<Q> {
     Ack {
         id: u64,
     },
+    /// Drops `count` of this endpoint's references to the peer's opaque `id`.
+    Release {
+        id: u64,
+        count: u32,
+    },
+}
+
+impl<Q: Send + 'static> crate::session::ReleaseSink for mpsc::WeakUnboundedSender<Outgoing<Q>> {
+    fn release(&self, id: u64, count: u32) {
+        // Called from `Drop`, so a departed channel is not an error: the
+        // writer is already gone and the peer's table dies with the session.
+        if let Some(outgoing) = self.upgrade() {
+            let _ = outgoing.send(Outgoing::Release { id, count });
+        }
+    }
 }
 
 struct Inner<P: Protocol> {
     // Holding a clone of this sender represents the ability to still get a
     // message into the writer, so closing the channel — clearing this to
     // `None` — is itself the writer's shutdown signal (see `Writer::run`):
-    // no separate oneshot needed.
+    // no separate oneshot needed. This is the only strong sender; the
+    // session's release sink holds a weak one so that it cannot keep the
+    // channel open past this point.
     outgoing: Mutex<Option<mpsc::UnboundedSender<Outgoing<P::Request>>>>,
     pending: Mutex<Pending<P::Response>>,
     next_id: Mutex<u64>,
@@ -130,6 +161,7 @@ struct Inner<P: Protocol> {
     handle_escrow: Mutex<HashMap<u64, Vec<OwnedHandle>>>,
     #[cfg(target_os = "macos")]
     fd_escrow: Mutex<crate::escrow::FdEscrow>,
+    session: Arc<Session>,
     limits: Limits,
     #[cfg(windows)]
     _peer_process: Option<OwnedHandle>,
@@ -233,6 +265,7 @@ impl<P: Protocol> Client<P> {
         #[cfg(windows)] peer_process: Option<OwnedHandle>,
     ) -> Self {
         let (outgoing, outgoing_rx) = mpsc::unbounded_channel();
+        let session = Session::new(Box::new(outgoing.downgrade()));
         let inner = Arc::new(Inner {
             outgoing: Mutex::new(Some(outgoing)),
             pending: Mutex::new(HashMap::new()),
@@ -242,6 +275,7 @@ impl<P: Protocol> Client<P> {
             handle_escrow: Mutex::new(HashMap::new()),
             #[cfg(target_os = "macos")]
             fd_escrow: Mutex::new(Default::default()),
+            session,
             limits,
             #[cfg(windows)]
             _peer_process: peer_process,
@@ -505,6 +539,10 @@ impl<P: Protocol> Writer<P> {
                 scheduler.admit_empty(Kind::Ack, id);
                 Ok(())
             }
+            Outgoing::Release { id, count } => {
+                scheduler.admit_release(id, count);
+                Ok(())
+            }
         }
     }
 
@@ -523,14 +561,28 @@ impl<P: Protocol> Writer<P> {
         };
         #[cfg(windows)]
         let max_handles = self.limits.max_handles_per_message;
-        let mut put_handles = EncodeHandles::new(&self.transport, max_handles);
+        let Some(inner) = self.inner.upgrade() else {
+            return Ok(());
+        };
+        let mut ledger = Ledger::default();
+        let mut put_handles = SessionFrame {
+            inner: EncodeHandles::new(&self.transport, max_handles),
+            session: &inner.session,
+            ledger: &mut ledger,
+        };
         let payload = match encode_payload(&value, &mut put_handles) {
             Ok(payload) => payload,
             Err(err) => {
+                // The ledger drops here without committing. Nothing of this
+                // message reached the wire, so any gift it named is rescinded
+                // by that drop path, not by a commit.
+                drop(put_handles);
+                ledger.rescind();
                 self.complete_err(id, err);
                 return Ok(());
             }
         };
+        let put_handles = put_handles.inner;
         #[cfg(unix)]
         let handles = put_handles.finish();
         #[cfg(target_os = "macos")]
@@ -547,7 +599,7 @@ impl<P: Protocol> Writer<P> {
         {
             inner.handle_escrow.lock().unwrap().insert(id, escrow);
         }
-        scheduler.admit_message(Kind::Request, id, payload, handles, trailer);
+        scheduler.admit_message(Kind::Request, id, payload, handles, trailer, ledger);
         Ok(())
     }
 
@@ -652,12 +704,28 @@ impl<P: Protocol> Reader<P> {
         let _ = handles;
         match kind {
             Kind::Response => {
+                // Decoding happens here, in the reader task, *before*
+                // `complete` discovers whether anyone still wants this
+                // response — and that ordering is load-bearing, not
+                // incidental. Decoding is what mirrors any opaque the payload
+                // carries; the resulting `CallResult` is then dropped
+                // normally when the call was cancelled, which releases those
+                // references back to the peer. Skipping the decode for a
+                // response nobody is waiting on would look like an
+                // optimization and would silently leak every handle in it —
+                // on a VFS pipe, a leak that hangs shutdown forever.
                 #[cfg(unix)]
-                let response = decode_payload(&payload, &mut { handles })?;
+                let response = decode_payload(
+                    &payload,
+                    &mut SessionHandles {
+                        inner: handles,
+                        session: &inner.session,
+                    },
+                )?;
                 #[cfg(windows)]
                 let response = decode_payload(
                     &payload,
-                    &mut DecodeHandles::new(self.limits.max_handles_per_message),
+                    &mut DecodeHandles::new(self.limits.max_handles_per_message, &inner.session),
                 )?;
                 let trailer = trailer.map(TrailerRecv::new);
                 #[cfg(windows)]
@@ -765,6 +833,11 @@ impl<P: Protocol> Reader<P> {
                     }
                     lease.complete();
                 }
+                Event::Release { id, count } => {
+                    if let Some(inner) = self.inner.upgrade() {
+                        inner.session.release(id, count);
+                    }
+                }
             }
         }
     }
@@ -794,7 +867,7 @@ mod tests {
     fn pending_call() -> (Call<Test>, mpsc::UnboundedReceiver<Outgoing<u8>>) {
         let (outgoing, outgoing_rx) = mpsc::unbounded_channel();
         let inner = Arc::new(Inner {
-            outgoing: Mutex::new(Some(outgoing)),
+            outgoing: Mutex::new(Some(outgoing.clone())),
             pending: Mutex::new(HashMap::new()),
             next_id: Mutex::new(1),
             tasks: Mutex::new(None),
@@ -802,6 +875,7 @@ mod tests {
             handle_escrow: Mutex::new(HashMap::new()),
             #[cfg(target_os = "macos")]
             fd_escrow: Mutex::new(Default::default()),
+            session: Session::new(Box::new(outgoing.downgrade())),
             limits: Limits::default(),
             #[cfg(windows)]
             _peer_process: None,
@@ -853,13 +927,14 @@ mod tests {
     async fn complete_err_clears_handle_escrow() {
         let (outgoing, _outgoing_rx) = mpsc::unbounded_channel();
         let inner = Arc::new(Inner {
-            outgoing: Mutex::new(Some(outgoing)),
+            outgoing: Mutex::new(Some(outgoing.clone())),
             pending: Mutex::new(HashMap::new()),
             next_id: Mutex::new(1),
             tasks: Mutex::new(None),
             handle_escrow: Mutex::new(HashMap::new()),
             #[cfg(target_os = "macos")]
             fd_escrow: Mutex::new(Default::default()),
+            session: Session::new(Box::new(outgoing.downgrade())),
             limits: Limits::default(),
             #[cfg(windows)]
             _peer_process: None,

--- a/dolang-rpc/src/client.rs
+++ b/dolang-rpc/src/client.rs
@@ -748,17 +748,10 @@ impl<P: Protocol> Reader<P> {
                 }
                 Event::Trailer {
                     id,
-                    message,
                     shared,
                     len,
                     notify_discard,
                 } => {
-                    if let Some(message) = message
-                        && let Err(error) = self.dispatch(message)
-                    {
-                        fail(&self.inner, error);
-                        return;
-                    }
                     if notify_discard && let Some(inner) = self.inner.upgrade() {
                         inner.send(Outgoing::DiscardTrailer { id });
                     }

--- a/dolang-rpc/src/client.rs
+++ b/dolang-rpc/src/client.rs
@@ -8,7 +8,7 @@ use std::{
 };
 
 #[cfg(windows)]
-use std::io;
+use std::{any::TypeId, io};
 
 use tokio::sync::{mpsc, oneshot};
 
@@ -32,10 +32,7 @@ use crate::{
     transport::{self, EncodeHandles, Receiver, Sender},
 };
 #[cfg(windows)]
-use crate::{
-    handle::TakeHandle,
-    session::{Ref, Session},
-};
+use crate::{handle::TakeHandle, session::Inner as OpaqueInner};
 
 /// A negotiated client endpoint that has not yet been bound to a [`Protocol`].
 ///
@@ -90,9 +87,15 @@ impl TakeHandle for DecodeHandles<'_> {
         Ok(())
     }
 
-    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<Ref> {
+    fn take_gift(&mut self, owner: u8, id: u64) -> io::Result<OpaqueInner> {
         self.session
-            .take(owner, id)
+            .take_gift(owner, id)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
+    }
+
+    fn take_cite(&mut self, owner: u8, id: u64, marker: TypeId) -> io::Result<OpaqueInner> {
+        self.session
+            .take_cite(owner, id, marker)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
     }
 }

--- a/dolang-rpc/src/fragment.rs
+++ b/dolang-rpc/src/fragment.rs
@@ -68,8 +68,11 @@ pub(crate) struct Flags(u8);
 impl Flags {
     pub(crate) const NONE: Flags = Flags(0);
     pub(crate) const FIRST: Flags = Flags(0b0001);
+    /// Last fragment of the message, whatever phase it is in.
     pub(crate) const LAST: Flags = Flags(0b0010);
     pub(crate) const ABORT: Flags = Flags(0b0100);
+    /// The postcard payload ends with this fragment and trailer data
+    /// follows.
     pub(crate) const TRAILER: Flags = Flags(0b1000);
     pub(crate) const WANT_ACK: Flags = Flags(0b1_0000);
     const VALID: u8 =
@@ -598,18 +601,18 @@ pub(crate) enum Event {
         id: u64,
         message: Option<Message>,
     },
+    /// A trailer-data fragment. The message it belongs to was handed to the
+    /// application earlier, at its payload boundary, so this never carries
+    /// one.
     Trailer {
         id: u64,
-        message: Option<Message>,
         shared: Arc<std::sync::Mutex<RecvShared>>,
         len: usize,
         /// Set when the local consumer had already discarded this trailer
-        /// (via [`crate::trailer::TrailerRecv::discard`] or by dropping it) before
-        /// this *subsequent* fragment arrived — i.e. the peer is still
-        /// sending more than we want. Never set on the fragment that first
-        /// hands the trailer to the application. The caller should tell the
-        /// peer to stop (`Kind::Discard`) exactly once per message when
-        /// this is set.
+        /// (via [`crate::trailer::TrailerRecv::discard`] or by dropping it)
+        /// before this fragment arrived — i.e. the peer is still sending
+        /// more than we want. The caller should tell the peer to stop
+        /// (`Kind::Discard`) exactly once per message when this is set.
         notify_discard: bool,
     },
 }
@@ -622,7 +625,14 @@ struct Incomplete {
     trailer_len: usize,
     dispatched: bool,
     discard_notified: bool,
-    postcard_done: bool,
+    /// Set once the fragment carrying `TRAILER` — the payload's last — has
+    /// arrived. Every fragment after it is trailer data.
+    trailer_phase: bool,
+    /// Set by a `WANT_ACK` fragment, which a well-behaved peer only sends
+    /// once its payload is complete. Guards against a malformed peer
+    /// continuing the payload past the boundary it just asked us to
+    /// acknowledge, which would release its handle escrow early.
+    want_ack_boundary: bool,
 }
 
 /// Reassembles postcard data while handing trailer fragments to a live
@@ -680,7 +690,7 @@ impl Reassembler {
             }
         }
 
-        if want_ack && (trailer || abort || !matches!(kind, Kind::Request | Kind::Response)) {
+        if want_ack && (abort || !matches!(kind, Kind::Request | Kind::Response)) {
             return Err(Error::Protocol("invalid WANT_ACK fragment".into()));
         }
 
@@ -711,14 +721,24 @@ impl Reassembler {
             });
         }
 
-        if first && last && trailer {
+        if last && trailer {
             return Err(Error::Protocol(
-                "a trailer-bearing message cannot complete in its FIRST fragment".into(),
+                "TRAILER and LAST are mutually exclusive: a payload followed by a trailer has more fragments coming".into(),
             ));
         }
 
+        // `TRAILER` rides the payload's *last* fragment, so the fragment
+        // carrying it is still payload; only the ones after it are trailer
+        // data. A missing entry leaves this false and is reported as such
+        // by the non-FIRST branch below.
+        let trailer_phase = !first
+            && self
+                .incomplete
+                .get(&id)
+                .is_some_and(|entry| entry.trailer_phase);
+
         #[cfg(unix)]
-        if trailer && !fragment_handles.is_empty() {
+        if trailer_phase && !fragment_handles.is_empty() {
             return Err(Error::Protocol(
                 "trailer fragment contains file descriptor attachments".into(),
             ));
@@ -744,61 +764,39 @@ impl Reassembler {
                     "inconsistent message kind for message {id}"
                 )));
             }
-            if entry.trailer.is_some() && !trailer {
+            if entry.trailer_phase && trailer {
                 return Err(Error::Protocol(format!(
-                    "message {id} cannot return to postcard fragments once its trailer has started"
+                    "message {id} announced its payload boundary twice"
                 )));
             }
-            if entry.postcard_done && !trailer {
+            if entry.want_ack_boundary && !entry.trailer_phase {
                 return Err(Error::Protocol(format!(
                     "message {id} cannot continue after a WANT_ACK boundary"
                 )));
             }
         }
 
-        if trailer && last {
+        if trailer_phase && last {
+            // Terminal commit closing out the trailer stream. The message
+            // itself went to the application back when its payload ended,
+            // so there is nothing left to hand over here — even for a
+            // trailer that never carried a byte, whose stream was installed
+            // at that same boundary.
             if payload_len != 0 {
                 return Err(Error::Protocol(
-                    "TRAILER|LAST commit fragment must not carry a payload".into(),
+                    "trailer commit fragment must not carry a payload".into(),
                 ));
             }
-            let mut entry = self.incomplete.remove(&id).ok_or_else(|| {
-                Error::Protocol(format!(
-                    "fragment for message {id} without an active message"
-                ))
-            })?;
-            if entry.trailer.is_none() {
-                // Established and immediately finished by this same
-                // fragment (a present-but-empty trailer) — check the limit
-                // as if opening a new trailer stream, but there's nothing
-                // to decrement afterward since it never actually occupied a
-                // slot in `incomplete`.
-                if self.incomplete_trailers >= self.limits.max_incomplete_trailers {
-                    return Err(Error::Protocol("too many incomplete trailers".into()));
-                }
-            } else {
-                self.incomplete_trailers -= 1;
-            }
+            let entry = self
+                .incomplete
+                .remove(&id)
+                .expect("trailer phase implies an active message");
             let shared = entry
                 .trailer
-                .get_or_insert_with(|| {
-                    RecvShared::new(
-                        self.limits.trailer_recv_copy_threshold,
-                        self.limits.trailer_recv_demand_copy_threshold,
-                    )
-                })
-                .clone();
+                .expect("the payload boundary installs the trailer stream");
+            self.incomplete_trailers -= 1;
             RecvShared::finish(&shared);
-            if entry.dispatched {
-                return Ok(Event::None);
-            }
-            return Ok(Event::Message(Message {
-                kind,
-                id,
-                payload: entry.postcard.freeze(),
-                handles: entry.handles,
-                trailer: Some(shared),
-            }));
+            return Ok(Event::None);
         }
 
         let fragment_limit = if first && last {
@@ -867,58 +865,33 @@ impl Reassembler {
                     trailer_len: 0,
                     dispatched: false,
                     discard_notified: false,
-                    postcard_done: false,
+                    trailer_phase: false,
+                    want_ack_boundary: false,
                 },
             );
         }
         let entry = self.incomplete.get_mut(&id).unwrap();
 
-        if trailer {
+        if trailer_phase {
             if entry.trailer_len + payload_len > self.limits.max_trailer_size {
                 return Err(Error::Protocol(format!(
                     "message {id} exceeds the maximum trailer size"
                 )));
             }
-            if entry.trailer.is_none() {
-                if self.incomplete_trailers >= self.limits.max_incomplete_trailers {
-                    return Err(Error::Protocol("too many incomplete trailers".into()));
-                }
-                self.incomplete_trailers += 1;
-            }
             entry.trailer_len += payload_len;
             let shared = entry
                 .trailer
-                .get_or_insert_with(|| {
-                    RecvShared::new(
-                        self.limits.trailer_recv_copy_threshold,
-                        self.limits.trailer_recv_demand_copy_threshold,
-                    )
-                })
-                .clone();
-            let message = if entry.dispatched {
-                None
-            } else {
-                entry.dispatched = true;
-                Some(Message {
-                    kind,
-                    id,
-                    payload: entry.postcard.clone().freeze(),
-                    handles: std::mem::take(&mut entry.handles),
-                    trailer: Some(shared.clone()),
-                })
-            };
-            // Only a *subsequent* fragment (the message was already
-            // dispatched to the app on an earlier one) can trigger a
-            // notification — the very first trailer fragment hasn't given
-            // the application a chance to discard anything yet.
-            let notify_discard =
-                message.is_none() && !entry.discard_notified && RecvShared::is_discarded(&shared);
+                .clone()
+                .expect("the payload boundary installs the trailer stream");
+            // The application already has the message (it was dispatched at
+            // the payload boundary), so it has had a chance to discard the
+            // trailer by now.
+            let notify_discard = !entry.discard_notified && RecvShared::is_discarded(&shared);
             if notify_discard {
                 entry.discard_notified = true;
             }
             return Ok(Event::Trailer {
                 id,
-                message,
                 shared,
                 notify_discard,
                 len: payload_len,
@@ -954,7 +927,41 @@ impl Reassembler {
         }
 
         if want_ack {
-            entry.postcard_done = true;
+            entry.want_ack_boundary = true;
+        }
+
+        if trailer {
+            // The payload is complete and a trailer follows. Install the
+            // trailer stream and dispatch the message now, rather than
+            // waiting for the producer to emit its first fragment — a
+            // producer that stalls must not hold up a payload that has
+            // already arrived whole.
+            if self.incomplete_trailers >= self.limits.max_incomplete_trailers {
+                return Err(Error::Protocol("too many incomplete trailers".into()));
+            }
+            self.incomplete_trailers += 1;
+            let shared = RecvShared::new(
+                self.limits.trailer_recv_copy_threshold,
+                self.limits.trailer_recv_demand_copy_threshold,
+            );
+            entry.trailer = Some(shared.clone());
+            entry.trailer_phase = true;
+            entry.dispatched = true;
+            let message = Message {
+                kind,
+                id,
+                payload: entry.postcard.clone().freeze(),
+                handles: std::mem::take(&mut entry.handles),
+                trailer: Some(shared),
+            };
+            return Ok(if want_ack {
+                Event::Ack {
+                    id,
+                    message: Some(message),
+                }
+            } else {
+                Event::Message(message)
+            });
         }
 
         if last {
@@ -1362,8 +1369,16 @@ impl Scheduler {
             if first {
                 flags = flags | Flags::FIRST;
             }
-            if postcard_done && handles_done && send.trailer.is_none() {
-                flags = flags | Flags::LAST;
+            // The payload's final fragment always announces the boundary:
+            // `LAST` ends the message outright, `TRAILER` hands off to the
+            // trailer phase. Either way the peer can decode here.
+            if postcard_done && handles_done {
+                flags = flags
+                    | if send.trailer.is_none() {
+                        Flags::LAST
+                    } else {
+                        Flags::TRAILER
+                    };
             }
             #[cfg(target_os = "macos")]
             if postcard_done && handles_done && send.handles.escrow_tracking() {
@@ -1449,9 +1464,11 @@ impl Scheduler {
 
         // Terminal commit: only reachable once both phases above are
         // exhausted, which (given `must_open_with_postcard`) implies a
-        // trailer was present.
+        // trailer was present. The peer is already in the trailer phase —
+        // the payload's last fragment carried `TRAILER` — so this only has
+        // to close the message out.
         let header = FragmentHeader {
-            flags: Flags::TRAILER | Flags::LAST,
+            flags: Flags::LAST,
             kind: send.kind,
             id: send.id,
             payload_len: 0,
@@ -1673,35 +1690,34 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn want_ack_marks_the_boundary_before_a_trailer() {
+    async fn want_ack_and_trailer_share_the_payload_boundary() {
+        // Both flags mark "the payload is complete", so a message that has
+        // attachments to escrow *and* a trailer carries them on the same
+        // fragment. That fragment acknowledges and dispatches at once.
         let mut frame = FakeRecvFrame::new(fragment_bytes(
-            Flags::FIRST | Flags::WANT_ACK,
+            Flags::FIRST | Flags::TRAILER | Flags::WANT_ACK,
             7,
             Kind::Response,
             b"done",
         ));
         let mut reassembler = Reassembler::new(Limits::default());
         let header = read_fragment_header(&mut frame).await.unwrap();
-        assert!(matches!(
-            reassembler.accept(header, &mut frame).await.unwrap(),
-            Event::Ack {
-                id: 7,
-                message: None
-            }
-        ));
-
-        let mut frame = FakeRecvFrame::new(fragment_bytes(
-            Flags::TRAILER | Flags::LAST,
-            7,
-            Kind::Response,
-            b"",
-        ));
-        let header = read_fragment_header(&mut frame).await.unwrap();
-        let Event::Message(message) = reassembler.accept(header, &mut frame).await.unwrap() else {
-            panic!("terminal trailer commit completes the message");
+        let Event::Ack {
+            id: 7,
+            message: Some(message),
+        } = reassembler.accept(header, &mut frame).await.unwrap()
+        else {
+            panic!("expected the payload boundary to ack and dispatch together");
         };
         assert_eq!(&message.payload[..], b"done");
         assert!(message.trailer.is_some());
+
+        let mut frame = FakeRecvFrame::new(fragment_bytes(Flags::LAST, 7, Kind::Response, b""));
+        let header = read_fragment_header(&mut frame).await.unwrap();
+        assert!(matches!(
+            reassembler.accept(header, &mut frame).await.unwrap(),
+            Event::None
+        ));
     }
 
     #[tokio::test]
@@ -1946,7 +1962,7 @@ mod tests {
         let header = read_fragment_header(&mut frame).await.unwrap();
         assert!(matches!(
             reassembler.accept(header, &mut frame).await.unwrap(),
-            Event::Trailer { .. }
+            Event::Message(_)
         ));
 
         let mut frame = FakeRecvFrame::new(fragment_bytes(
@@ -2024,60 +2040,45 @@ mod tests {
 
     #[tokio::test]
     async fn present_but_empty_trailer_is_distinguishable_from_absent() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"hello");
-        bytes.extend(fragment_bytes(
-            Flags::TRAILER | Flags::LAST,
-            1,
-            Kind::Request,
-            b"",
-        ));
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"hello");
+        bytes.extend(fragment_bytes(Flags::LAST, 1, Kind::Request, b""));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
         let header = read_fragment_header(&mut frame).await.unwrap();
-        assert!(matches!(
-            reassembler.accept(header, &mut frame).await.unwrap(),
-            Event::None
-        ));
-        let header = read_fragment_header(&mut frame).await.unwrap();
         let Event::Message(msg) = reassembler.accept(header, &mut frame).await.unwrap() else {
-            panic!("TRAILER|LAST completes the message");
+            panic!("the payload boundary completes the message");
         };
         assert_eq!(&msg.payload[..], b"hello");
         assert!(
             msg.trailer.is_some(),
-            "a TRAILER fragment was seen, even though its content is empty"
+            "TRAILER was seen, even though no trailer data ever followed"
         );
-    }
-
-    #[tokio::test]
-    async fn single_fragment_trailer_reassembles_with_postcard_payload() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"hello");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"world"));
-        bytes.extend(fragment_bytes(
-            Flags::TRAILER | Flags::LAST,
-            1,
-            Kind::Request,
-            b"",
-        ));
-        let mut frame = FakeRecvFrame::new(bytes);
-        let mut reassembler = Reassembler::new(Limits::default());
-
         let header = read_fragment_header(&mut frame).await.unwrap();
         assert!(matches!(
             reassembler.accept(header, &mut frame).await.unwrap(),
             Event::None
         ));
+    }
+
+    #[tokio::test]
+    async fn single_fragment_trailer_reassembles_with_postcard_payload() {
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"hello");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"world"));
+        bytes.extend(fragment_bytes(Flags::LAST, 1, Kind::Request, b""));
+        let mut frame = FakeRecvFrame::new(bytes);
+        let mut reassembler = Reassembler::new(Limits::default());
 
         let header = read_fragment_header(&mut frame).await.unwrap();
-        let Event::Trailer {
-            message: Some(msg),
-            len,
-            ..
-        } = reassembler.accept(header, &mut frame).await.unwrap()
-        else {
-            panic!("expected the first TRAILER fragment to dispatch the message");
+        let Event::Message(msg) = reassembler.accept(header, &mut frame).await.unwrap() else {
+            panic!("expected the payload boundary to dispatch the message");
         };
         assert_eq!(&msg.payload[..], b"hello");
+
+        let header = read_fragment_header(&mut frame).await.unwrap();
+        let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
+        else {
+            panic!("expected a trailer-data fragment");
+        };
         assert_eq!(&drain_trailer_bytes(&mut frame, len).await[..], b"world");
 
         let header = read_fragment_header(&mut frame).await.unwrap();
@@ -2089,42 +2090,30 @@ mod tests {
 
     #[tokio::test]
     async fn multi_fragment_trailer_reassembles_with_empty_postcard_payload() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"ab"));
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"cd"));
-        bytes.extend(fragment_bytes(
-            Flags::TRAILER | Flags::LAST,
-            1,
-            Kind::Request,
-            b"",
-        ));
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"ab"));
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"cd"));
+        bytes.extend(fragment_bytes(Flags::LAST, 1, Kind::Request, b""));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
 
         let header = read_fragment_header(&mut frame).await.unwrap();
-        assert!(matches!(
-            reassembler.accept(header, &mut frame).await.unwrap(),
-            Event::None
-        ));
-
-        let header = read_fragment_header(&mut frame).await.unwrap();
-        let Event::Trailer {
-            message: Some(msg),
-            len,
-            ..
-        } = reassembler.accept(header, &mut frame).await.unwrap()
-        else {
-            panic!("expected the first TRAILER fragment to dispatch the message");
+        let Event::Message(msg) = reassembler.accept(header, &mut frame).await.unwrap() else {
+            panic!("expected the payload boundary to dispatch the message");
         };
         assert_eq!(&msg.payload[..], b"");
+
+        let header = read_fragment_header(&mut frame).await.unwrap();
+        let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
+        else {
+            panic!("expected the first trailer-data fragment");
+        };
         assert_eq!(&drain_trailer_bytes(&mut frame, len).await[..], b"ab");
 
         let header = read_fragment_header(&mut frame).await.unwrap();
-        let Event::Trailer {
-            message: None, len, ..
-        } = reassembler.accept(header, &mut frame).await.unwrap()
+        let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
         else {
-            panic!("expected a subsequent TRAILER fragment to not redispatch the message");
+            panic!("expected a subsequent trailer-data fragment");
         };
         assert_eq!(&drain_trailer_bytes(&mut frame, len).await[..], b"cd");
 
@@ -2137,14 +2126,9 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_trailer_last_commit_with_nonzero_payload() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"a"));
-        bytes.extend(fragment_bytes(
-            Flags::TRAILER | Flags::LAST,
-            1,
-            Kind::Request,
-            b"x",
-        ));
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"a"));
+        bytes.extend(fragment_bytes(Flags::LAST, 1, Kind::Request, b"x"));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
 
@@ -2166,27 +2150,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn first_trailer_fragment_starts_trailer_phase_immediately_with_empty_postcard() {
-        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"ab");
-        bytes.extend(fragment_bytes(
-            Flags::TRAILER | Flags::LAST,
-            1,
-            Kind::Request,
-            b"",
-        ));
+    async fn payload_boundary_dispatches_before_any_trailer_data_arrives() {
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"ab"));
+        bytes.extend(fragment_bytes(Flags::LAST, 1, Kind::Request, b""));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
 
+        // The whole point of putting TRAILER on the payload's last fragment:
+        // the message is available without waiting on the trailer producer.
         let header = read_fragment_header(&mut frame).await.unwrap();
-        let Event::Trailer {
-            message: Some(msg),
-            len,
-            ..
-        } = reassembler.accept(header, &mut frame).await.unwrap()
-        else {
+        let Event::Message(msg) = reassembler.accept(header, &mut frame).await.unwrap() else {
             panic!("expected FIRST|TRAILER to dispatch the message immediately");
         };
         assert_eq!(&msg.payload[..], b"");
+        assert!(msg.trailer.is_some());
+
+        let header = read_fragment_header(&mut frame).await.unwrap();
+        let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
+        else {
+            panic!("expected a trailer-data fragment");
+        };
         assert_eq!(&drain_trailer_bytes(&mut frame, len).await[..], b"ab");
 
         let header = read_fragment_header(&mut frame).await.unwrap();
@@ -2197,26 +2181,27 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_first_last_trailer_together() {
-        let mut frame = FakeRecvFrame::new(fragment_bytes(
+    async fn rejects_last_and_trailer_together() {
+        // Mutually exclusive: TRAILER promises more fragments, LAST denies it.
+        for flags in [
             Flags::FIRST | Flags::LAST | Flags::TRAILER,
-            1,
-            Kind::Request,
-            b"",
-        ));
-        let mut reassembler = Reassembler::new(Limits::default());
-        let header = read_fragment_header(&mut frame).await.unwrap();
-        assert!(matches!(
-            reassembler.accept(header, &mut frame).await,
-            Err(Error::Protocol(_))
-        ));
+            Flags::LAST | Flags::TRAILER,
+        ] {
+            let mut frame = FakeRecvFrame::new(fragment_bytes(flags, 1, Kind::Request, b""));
+            let mut reassembler = Reassembler::new(Limits::default());
+            let header = read_fragment_header(&mut frame).await.unwrap();
+            assert!(matches!(
+                reassembler.accept(header, &mut frame).await,
+                Err(Error::Protocol(_))
+            ));
+        }
     }
 
     #[tokio::test]
-    async fn rejects_fragment_returning_to_postcard_after_trailer_started() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"a"));
-        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"b"));
+    async fn rejects_a_second_payload_boundary() {
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"a"));
+        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"b"));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
 
@@ -2226,7 +2211,7 @@ mod tests {
         let header = read_fragment_header(&mut frame).await.unwrap();
         let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
         else {
-            panic!("expected a TRAILER data event");
+            panic!("expected a trailer-data fragment");
         };
         drain_trailer_bytes(&mut frame, len).await;
 
@@ -2250,15 +2235,18 @@ mod tests {
             ..Limits::default()
         };
         let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"abcd");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"ab"));
+        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"abcd"));
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"ab"));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(limits);
         let header = read_fragment_header(&mut frame).await.unwrap();
         reassembler.accept(header, &mut frame).await.unwrap();
         let header = read_fragment_header(&mut frame).await.unwrap();
+        reassembler.accept(header, &mut frame).await.unwrap();
+        let header = read_fragment_header(&mut frame).await.unwrap();
         let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
         else {
-            panic!("expected a TRAILER data event, not rejection");
+            panic!("expected a trailer-data fragment, not rejection");
         };
         drain_trailer_bytes(&mut frame, len).await;
     }
@@ -2270,8 +2258,8 @@ mod tests {
             max_trailer_size: 3,
             ..Limits::default()
         };
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"abcd"));
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"abcd"));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(limits);
         let header = read_fragment_header(&mut frame).await.unwrap();
@@ -2285,8 +2273,8 @@ mod tests {
 
     #[tokio::test]
     async fn abort_during_trailer_phase_discards_both_buffers() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"ab");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"cd"));
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"ab");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"cd"));
         bytes.extend(fragment_bytes(Flags::ABORT, 1, Kind::Request, b""));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
@@ -2297,7 +2285,7 @@ mod tests {
         let header = read_fragment_header(&mut frame).await.unwrap();
         let Event::Trailer { len, .. } = reassembler.accept(header, &mut frame).await.unwrap()
         else {
-            panic!("expected a TRAILER data event");
+            panic!("expected a trailer-data fragment");
         };
         drain_trailer_bytes(&mut frame, len).await;
         assert_eq!(reassembler.incomplete_trailers, 1);
@@ -2688,63 +2676,47 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn notify_discard_fires_only_on_a_subsequent_fragment_after_local_discard() {
-        let mut bytes = fragment_bytes(Flags::FIRST, 1, Kind::Request, b"");
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"a"));
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"b"));
-        bytes.extend(fragment_bytes(Flags::TRAILER, 1, Kind::Request, b"c"));
+    async fn notify_discard_fires_exactly_once_after_local_discard() {
+        let mut bytes = fragment_bytes(Flags::FIRST | Flags::TRAILER, 1, Kind::Request, b"");
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"a"));
+        bytes.extend(fragment_bytes(Flags::NONE, 1, Kind::Request, b"b"));
         let mut frame = FakeRecvFrame::new(bytes);
         let mut reassembler = Reassembler::new(Limits::default());
 
+        // The payload boundary hands over the message and its trailer stream.
         let header = read_fragment_header(&mut frame).await.unwrap();
-        reassembler.accept(header, &mut frame).await.unwrap();
-
-        // First TRAILER fragment dispatches the message. `notify_discard`
-        // must never fire here — the application hasn't had a chance to
-        // discard anything yet.
-        let header = read_fragment_header(&mut frame).await.unwrap();
-        let Event::Trailer {
-            message: Some(_),
-            shared,
-            len,
-            notify_discard,
-            ..
-        } = reassembler.accept(header, &mut frame).await.unwrap()
-        else {
-            panic!("expected the first TRAILER fragment to dispatch the message");
+        let Event::Message(msg) = reassembler.accept(header, &mut frame).await.unwrap() else {
+            panic!("expected the payload boundary to dispatch the message");
         };
-        assert!(!notify_discard);
-        drain_trailer_bytes(&mut frame, len).await;
+        let shared = msg.trailer.expect("trailer stream");
 
-        // The application decides to stop reading.
+        // The application decides to stop reading before any trailer data
+        // has even arrived — which the payload-boundary dispatch now makes
+        // possible, so the very first trailer fragment can be the one that
+        // notifies.
         RecvShared::discard(&shared);
 
-        // Second TRAILER fragment: arrives after the discard, so this is
-        // the point where the peer should be told to stop.
         let header = read_fragment_header(&mut frame).await.unwrap();
         let Event::Trailer {
-            message: None,
             len,
             notify_discard,
             ..
         } = reassembler.accept(header, &mut frame).await.unwrap()
         else {
-            panic!("expected a subsequent TRAILER data event");
+            panic!("expected a trailer-data fragment");
         };
         assert!(notify_discard);
         drain_trailer_bytes(&mut frame, len).await;
 
-        // Third TRAILER fragment: already notified once, must not fire
-        // again for the same message.
+        // Already notified once; must not fire again for the same message.
         let header = read_fragment_header(&mut frame).await.unwrap();
         let Event::Trailer {
-            message: None,
             len,
             notify_discard,
             ..
         } = reassembler.accept(header, &mut frame).await.unwrap()
         else {
-            panic!("expected a subsequent TRAILER data event");
+            panic!("expected a trailer-data fragment");
         };
         assert!(!notify_discard);
         drain_trailer_bytes(&mut frame, len).await;
@@ -2774,10 +2746,12 @@ mod tests {
         let mut trailer = crate::trailer::TrailerSend::new(shared, ());
         let (mut sender, mut reader) = sender_pair();
 
-        // Postcard phase: FIRST, no LAST (a trailer is pending).
+        // Postcard phase: FIRST plus TRAILER, since this is also the
+        // payload's last fragment and a trailer is pending.
         scheduler.advance(&mut sender).await.unwrap();
         let (flags, _, id, payload) = read_wire_fragment(&mut reader).await;
-        assert!(flags.contains(Flags::FIRST) && !flags.contains(Flags::LAST));
+        assert!(flags.contains(Flags::FIRST) && flags.contains(Flags::TRAILER));
+        assert!(!flags.contains(Flags::LAST));
         assert_eq!(id, 1);
         assert_eq!(payload, b"hi");
 
@@ -2789,7 +2763,11 @@ mod tests {
         });
         scheduler.advance(&mut sender).await.unwrap();
         let (flags, _, id, payload) = read_wire_fragment(&mut reader).await;
-        assert!(flags.contains(Flags::TRAILER) && !flags.contains(Flags::LAST));
+        assert_eq!(
+            flags,
+            Flags::NONE,
+            "trailer data carries no flags of its own"
+        );
         assert_eq!(id, 1);
         assert_eq!(payload, b"data");
         let mut trailer = writer.await.unwrap();
@@ -2802,12 +2780,11 @@ mod tests {
         let error = trailer.write_all(b"more").await.unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
 
-        // The next turn is an ordinary zero-length TRAILER | LAST terminal
-        // commit -- not an ABORT -- exactly as if the trailer had completed
-        // normally.
+        // The next turn is an ordinary zero-length LAST terminal commit --
+        // not an ABORT -- exactly as if the trailer had completed normally.
         scheduler.advance(&mut sender).await.unwrap();
         let (flags, _, id, payload) = read_wire_fragment(&mut reader).await;
-        assert!(flags.contains(Flags::TRAILER) && flags.contains(Flags::LAST));
+        assert!(flags.contains(Flags::LAST));
         assert!(!flags.contains(Flags::ABORT));
         assert_eq!(id, 1);
         assert!(payload.is_empty());

--- a/dolang-rpc/src/fragment.rs
+++ b/dolang-rpc/src/fragment.rs
@@ -16,6 +16,7 @@ use ::serde::{Deserialize, Serialize};
 
 use crate::{
     Error, Limits, NEGOTIATE_FRAGMENT_SIZE, NEGOTIATE_MAX_PAYLOAD_SIZE,
+    session::Ledger,
     trailer::{RecvShared, SendAction, SendShared},
     transport::{
         AnyReceiver, AnySender, OutgoingHandles, ReceivedHandles, Receiver, RecvFrame, SendFrame,
@@ -42,6 +43,22 @@ pub(crate) enum Kind {
     /// Confirms receipt of the final non-trailer fragment carrying
     /// `WANT_ACK` for the message identified by `id`.
     Ack = 6,
+    /// Drops references to a session opaque. `id` names the opaque rather
+    /// than a message, and the 4-byte payload carries how many references
+    /// are being dropped at once.
+    ///
+    /// This lives at transport level, not in any [`Protocol`](crate::Protocol),
+    /// because [`Opaque`](crate::session::Opaque) is generic over the
+    /// application protocol: releasing is the RPC runtime's business, and an
+    /// application that never names an opaque still needs its peer's
+    /// references collected.
+    ///
+    /// A release for an unknown `id` is ignored rather than treated as a
+    /// protocol error. The owner may legitimately have retired the entry
+    /// already — a consuming operation races the peer's release by
+    /// construction, and the counters are commutative, so both orders
+    /// converge.
+    Release = 7,
 }
 
 impl TryFrom<u8> for Kind {
@@ -56,6 +73,7 @@ impl TryFrom<u8> for Kind {
             4 => Ok(Self::Discard),
             5 => Ok(Self::Negotiate),
             6 => Ok(Self::Ack),
+            7 => Ok(Self::Release),
             _ => Err(Error::Protocol(format!("unknown frame kind {value}"))),
         }
     }
@@ -615,6 +633,12 @@ pub(crate) enum Event {
         /// (`Kind::Discard`) exactly once per message when this is set.
         notify_discard: bool,
     },
+    /// The peer dropped `count` references to the opaque named by `id`.
+    /// Unknown ids are tolerated; see [`Kind::Release`].
+    Release {
+        id: u64,
+        count: u32,
+    },
 }
 
 struct Incomplete {
@@ -688,6 +712,25 @@ impl Reassembler {
             if !first || !last || abort || trailer || want_ack || payload_len != 0 || has_handles {
                 return Err(Error::Protocol("invalid Ack fragment".into()));
             }
+        }
+
+        if kind == Kind::Release {
+            #[cfg(unix)]
+            let has_handles = !fragment_handles.is_empty();
+            #[cfg(not(unix))]
+            let has_handles = false;
+            if !first || !last || abort || trailer || want_ack || payload_len != 4 || has_handles {
+                return Err(Error::Protocol("invalid Release fragment".into()));
+            }
+            let mut payload = BytesMut::with_capacity(4);
+            read_payload(frame, &mut payload, 4).await?;
+            let count = payload.get_u32_le();
+            if count == 0 {
+                return Err(Error::Protocol(
+                    "Release fragment must drop at least one reference".into(),
+                ));
+            }
+            return Ok(Event::Release { id, count });
         }
 
         if want_ack && (abort || !matches!(kind, Kind::Request | Kind::Response)) {
@@ -1031,13 +1074,22 @@ struct ActiveSend {
     /// in one fragment at admission time, or a trailer is present — a
     /// trailer-bearing message is always at least two fragments).
     multi_fragment: bool,
+    /// Session opaque references this message's payload is holding.
+    ///
+    /// Cleared — which commits it — the instant the payload's last fragment
+    /// is written, and rescinded if the send is cancelled before then. Living
+    /// on the send rather than in the endpoints is what makes that boundary
+    /// unmissable: the scheduler is the only thing that knows where the
+    /// payload actually ends.
+    ledger: Option<Ledger>,
 }
 
-/// A control-priority item: a zero-payload `Cancel`/`Error`/`Ack`, or an `ABORT`
-/// for a message whose FIRST fragment already went out.
+/// A control-priority item: a zero-payload `Cancel`/`Error`/`Ack`, an `ABORT`
+/// for a message whose FIRST fragment already went out, or a `Release`.
 enum ControlSend {
     Empty { kind: Kind, id: u64 },
     Abort { id: u64 },
+    Release { id: u64, count: u32 },
 }
 
 /// Outcome of attempting to cancel an in-flight outbound send.
@@ -1147,6 +1199,7 @@ impl Scheduler {
         payload: Bytes,
         handles: OutgoingHandles,
         trailer: Trailer,
+        ledger: Ledger,
     ) {
         #[cfg(unix)]
         let handles_fit = handles.fds.len() <= self.max_handles_per_fragment;
@@ -1167,6 +1220,7 @@ impl Scheduler {
                 trailer,
                 started: false,
                 multi_fragment: false,
+                ledger: Some(ledger),
             });
             return;
         }
@@ -1182,6 +1236,7 @@ impl Scheduler {
             trailer,
             started: false,
             multi_fragment: true,
+            ledger: Some(ledger),
         };
         if self.active_fragmented < self.max_active_fragmented {
             self.active_fragmented += 1;
@@ -1203,6 +1258,19 @@ impl Scheduler {
         self.control.push_back(ControlSend::Abort { id });
     }
 
+    /// Admits a `Release` for `count` references to the opaque `id`, ahead of
+    /// ordinary sends.
+    ///
+    /// Ordering against ordinary sends is not a correctness requirement here:
+    /// a message that *cites* an opaque holds a reference in the send escrow
+    /// until its payload is fully written, so no release for a cited opaque
+    /// can be admitted before the citing message's last payload fragment
+    /// leaves.
+    pub(crate) fn admit_release(&mut self, id: u64, count: u32) {
+        debug_assert!(count > 0, "a release must drop at least one reference");
+        self.control.push_back(ControlSend::Release { id, count });
+    }
+
     /// Attempts to cancel an in-flight or not-yet-started outbound send.
     ///
     /// If the send carries a `Trailer::Stream`, its `SendShared` is put into
@@ -1212,17 +1280,27 @@ impl Scheduler {
     /// `Arc`, are gone after this call).
     pub(crate) fn try_cancel_active(&mut self, id: u64) -> AbortOutcome {
         if let Some(pos) = self.waiting.iter().position(|s| s.id == id) {
-            let send = self.waiting.remove(pos).expect("position was just found");
+            let mut send = self.waiting.remove(pos).expect("position was just found");
             if let Trailer::Stream(shared) = &send.trailer {
                 SendShared::discard(shared);
+            }
+            // Nothing of this message ever reached the wire.
+            if let Some(ledger) = send.ledger.take() {
+                ledger.rescind();
             }
             return AbortOutcome::Discarded { started: false };
         }
         if let Some(pos) = self.active.iter().position(|s| s.id == id) {
-            let send = self.active.remove(pos).expect("position was just found");
+            let mut send = self.active.remove(pos).expect("position was just found");
             let started = send.started;
             if let Trailer::Stream(shared) = &send.trailer {
                 SendShared::discard(shared);
+            }
+            // Present only while the payload is still incomplete: the write
+            // path clears it at the payload boundary. So this rescinds
+            // exactly the sends the peer cannot have decoded, and no others.
+            if let Some(ledger) = send.ledger.take() {
+                ledger.rescind();
             }
             if send.multi_fragment {
                 self.free_fragmented_slot();
@@ -1393,6 +1471,17 @@ impl Scheduler {
             let mut buffer = header.encode().chain(send.payload.slice(start..end));
             let atomic = frame.finish(&mut buffer).await?;
             self.record_write_atomicity(atomic);
+            if postcard_done && handles_done {
+                // The payload is irrevocably on the wire, so the peer will
+                // decode it and mirror every gift it carries even if it has
+                // already cancelled the call. Dropping the ledger commits it;
+                // a cancellation arriving from here on finds nothing left to
+                // rescind, which is the intended asymmetry — a stranded
+                // reference beats handing the peer a freed handle.
+                if let Some(ledger) = send.ledger.take() {
+                    ledger.commit();
+                }
+            }
             send.offset = end;
             #[cfg(target_os = "macos")]
             let escrow = send.handles.finish_attached(attached);
@@ -1486,21 +1575,44 @@ impl Scheduler {
         transport: &mut AnySender,
         control: ControlSend,
     ) -> Result<(), Error> {
-        let header = match control {
-            ControlSend::Empty { kind, id } => FragmentHeader {
-                flags: Flags::FIRST | Flags::LAST,
-                kind,
-                id,
-                payload_len: 0,
-            },
-            ControlSend::Abort { id } => FragmentHeader {
-                flags: Flags::ABORT,
-                kind: Kind::Request,
-                id,
-                payload_len: 0,
-            },
+        let (header, count) = match control {
+            ControlSend::Empty { kind, id } => (
+                FragmentHeader {
+                    flags: Flags::FIRST | Flags::LAST,
+                    kind,
+                    id,
+                    payload_len: 0,
+                },
+                None,
+            ),
+            ControlSend::Abort { id } => (
+                FragmentHeader {
+                    flags: Flags::ABORT,
+                    kind: Kind::Request,
+                    id,
+                    payload_len: 0,
+                },
+                None,
+            ),
+            ControlSend::Release { id, count } => (
+                FragmentHeader {
+                    flags: Flags::FIRST | Flags::LAST,
+                    kind: Kind::Release,
+                    id,
+                    payload_len: 4,
+                },
+                Some(count),
+            ),
         };
-        let mut buffer = header.encode();
+        let mut buffer = match count {
+            None => header.encode(),
+            Some(count) => {
+                let mut buffer = BytesMut::with_capacity(RawFragmentHeader::LEN + 4);
+                header.encode_into(&mut buffer);
+                buffer.put_u32_le(count);
+                buffer.freeze()
+            }
+        };
         transport.send().finish(&mut buffer).await?;
         Ok(())
     }
@@ -2375,6 +2487,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         scheduler.admit_message(
             Kind::Request,
@@ -2382,6 +2495,7 @@ mod tests {
             Bytes::from_static(b"BBBBBBBB"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         let (mut sender, mut reader) = sender_pair();
 
@@ -2406,6 +2520,7 @@ mod tests {
             Bytes::from_static(b"request"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         scheduler.admit_empty(Kind::Ack, 2);
         let (mut sender, mut reader) = sender_pair();
@@ -2433,6 +2548,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         // Fits in one fragment; must not be blocked by the slot above.
         scheduler.admit_message(
@@ -2441,6 +2557,7 @@ mod tests {
             Bytes::from_static(b"hi"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         let (mut sender, mut reader) = sender_pair();
 
@@ -2469,6 +2586,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         scheduler.admit_message(
             Kind::Request,
@@ -2476,6 +2594,7 @@ mod tests {
             Bytes::from_static(b"BBBBBBBB"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         assert_eq!(scheduler.active.len(), 1);
         assert_eq!(scheduler.waiting.len(), 1);
@@ -2495,6 +2614,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         let (mut sender, mut reader) = sender_pair();
         loop {
@@ -2521,6 +2641,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         scheduler.admit_message(
             Kind::Request,
@@ -2528,6 +2649,7 @@ mod tests {
             Bytes::from_static(b"BBBBBBBB"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         assert_eq!(scheduler.waiting.len(), 1);
         let (mut sender, mut reader) = sender_pair();
@@ -2555,6 +2677,7 @@ mod tests {
             Bytes::from_static(b"hi"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         scheduler.active.pop_front();
         assert!(matches!(
@@ -2572,6 +2695,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         match scheduler.try_cancel_active(1) {
             AbortOutcome::Discarded { started } => assert!(!started),
@@ -2592,6 +2716,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         if let Some(send) = scheduler.active.front_mut() {
             send.offset = 4;
@@ -2617,6 +2742,7 @@ mod tests {
             Bytes::from_static(b"AAAAAAAA"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         scheduler.admit_message(
             Kind::Request,
@@ -2624,6 +2750,7 @@ mod tests {
             Bytes::from_static(b"BBBBBBBB"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         assert_eq!(scheduler.waiting.len(), 1);
         match scheduler.try_cancel_active(2) {
@@ -2659,6 +2786,7 @@ mod tests {
                     ..limits
                 },
             )),
+            Default::default(),
         );
         assert_eq!(scheduler.active.len(), 1);
         assert_eq!(scheduler.active_fragmented, 1);
@@ -2670,6 +2798,7 @@ mod tests {
             Bytes::from_static(b"hi"),
             Default::default(),
             Trailer::None,
+            Default::default(),
         );
         assert_eq!(scheduler.active.len(), 2);
         assert_eq!(scheduler.waiting.len(), 0);
@@ -2742,6 +2871,7 @@ mod tests {
             Bytes::from_static(b"hi"),
             Default::default(),
             Trailer::Stream(shared.clone()),
+            Default::default(),
         );
         let mut trailer = crate::trailer::TrailerSend::new(shared, ());
         let (mut sender, mut reader) = sender_pair();

--- a/dolang-rpc/src/handle.rs
+++ b/dolang-rpc/src/handle.rs
@@ -24,7 +24,7 @@ pub(crate) trait PutHandle {
     fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<usize>;
     /// Records a session opaque encountered during serialization, returning
     /// its wire `(owner, id)`.
-    fn put_opaque(&mut self, opaque: &crate::session::Ref) -> io::Result<(u8, u64)>;
+    fn put_opaque(&mut self, opaque: &crate::session::Inner) -> io::Result<(u8, u64)>;
 }
 
 pub(crate) trait ErasedHandle {
@@ -44,8 +44,22 @@ pub(crate) trait TakeHandle {
     fn finish(&mut self) -> io::Result<()> {
         Ok(())
     }
-    /// Resolves an arriving wire `(owner, id)` against the receiving session.
-    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<crate::session::Ref>;
+    /// Resolves an arriving wire `(owner, id)` in a position declared to hold
+    /// a [`Gift`](crate::session::Gift) against the receiving session.
+    fn take_gift(&mut self, owner: u8, id: u64) -> io::Result<crate::session::Inner>;
+
+    /// Resolves an arriving wire `(owner, id)` in a position declared to hold
+    /// a [`Cite`](crate::session::Cite) against the receiving session.
+    ///
+    /// `marker` is the [`TypeId`](std::any::TypeId) of the marker type the
+    /// wire position declares, which the session checks against its own
+    /// registration for the id.
+    fn take_cite(
+        &mut self,
+        owner: u8,
+        id: u64,
+        marker: std::any::TypeId,
+    ) -> io::Result<crate::session::Inner>;
 }
 
 /// A native operating-system resource transferred as a frame attachment.

--- a/dolang-rpc/src/handle.rs
+++ b/dolang-rpc/src/handle.rs
@@ -1,20 +1,12 @@
-use std::{cell::Cell, fmt, fmt::Formatter, io, marker::PhantomData, str};
+use std::{cell::Cell, fmt, io};
 
 #[cfg(unix)]
 use std::os::fd::{AsFd, OwnedFd};
 
 #[cfg(windows)]
-use std::os::windows::io::{AsHandle, AsRawHandle, FromRawHandle, OwnedHandle, RawHandle};
+use std::os::windows::io::{AsHandle, OwnedHandle};
 
-use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
-
-// This must have a unique address: the serde wrappers use pointer identity to
-// ensure only this private newtype can invoke the unsafe handle path.
-static OS_HANDLE_TYPE_BYTES: [u8; 20] = *b"dolang_rpc::OsHandle";
-pub(crate) static OS_HANDLE_TYPE: &str = match str::from_utf8(&OS_HANDLE_TYPE_BYTES) {
-    Ok(value) => value,
-    Err(_) => panic!("invalid handle type marker"),
-};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 /// The platform's default owned native handle type.
 #[cfg(unix)]
@@ -25,31 +17,21 @@ pub type DefaultHandle = OwnedFd;
 pub type DefaultHandle = std::os::windows::io::OwnedHandle;
 
 /// Supplies native handles encountered during serialization.
-pub(crate) trait PutHandle<'handle> {
+pub(crate) trait PutHandle {
     #[cfg(unix)]
-    fn put_handle(&mut self, handle: &'handle dyn ErasedHandle) -> io::Result<u32>;
+    fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<u32>;
     #[cfg(windows)]
-    fn put_handle(&mut self, handle: &'handle dyn ErasedHandle) -> io::Result<usize>;
+    fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<usize>;
+    /// Records a session opaque encountered during serialization, returning
+    /// its wire `(owner, id)`.
+    fn put_opaque(&mut self, opaque: &crate::session::Ref) -> io::Result<(u8, u64)>;
 }
 
 pub(crate) trait ErasedHandle {
     #[cfg(unix)]
-    fn steal_handle(&self) -> OwnedFd;
+    fn steal_handle(&self) -> Option<OwnedFd>;
     #[cfg(windows)]
-    fn raw_handle(&self) -> RawHandle;
-    #[cfg(windows)]
-    fn steal_handle(&self) -> OwnedHandle;
-}
-
-pub(crate) struct HandleRef<'handle>(pub(crate) &'handle dyn ErasedHandle);
-
-impl Serialize for HandleRef<'_> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        #[cfg(target_pointer_width = "32")]
-        return serializer.serialize_u32(self as *const Self as usize as u32);
-        #[cfg(target_pointer_width = "64")]
-        return serializer.serialize_u64(self as *const Self as usize as u64);
-    }
+    fn steal_handle(&self) -> Option<OwnedHandle>;
 }
 
 /// Consumes native handles encountered during deserialization.
@@ -62,6 +44,8 @@ pub(crate) trait TakeHandle {
     fn finish(&mut self) -> io::Result<()> {
         Ok(())
     }
+    /// Resolves an arriving wire `(owner, id)` against the receiving session.
+    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<crate::session::Ref>;
 }
 
 /// A native operating-system resource transferred as a frame attachment.
@@ -106,114 +90,42 @@ impl<T> From<T> for OsHandle<T> {
 
 #[cfg(unix)]
 impl<T: AsFd + Into<OwnedFd>> ErasedHandle for OsHandle<T> {
-    fn steal_handle(&self) -> OwnedFd {
-        self.0
-            .take()
-            .expect("operating-system handle was already consumed")
-            .into()
+    fn steal_handle(&self) -> Option<OwnedFd> {
+        self.0.take().map(Into::into)
     }
 }
 
 #[cfg(unix)]
 impl<T: AsFd + Into<OwnedFd>> Serialize for OsHandle<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_newtype_struct(OS_HANDLE_TYPE, &HandleRef(self))
+        crate::serde::serialize_handle(self, serializer)
     }
 }
 
 #[cfg(unix)]
 impl<'de, T: From<OwnedFd>> Deserialize<'de> for OsHandle<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct Visitor<T>(PhantomData<T>);
-
-        impl<'de, T: From<OwnedFd>> de::Visitor<'de> for Visitor<T> {
-            type Value = OsHandle<T>;
-
-            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("an operating-system handle")
-            }
-
-            fn visit_newtype_struct<D: Deserializer<'de>>(
-                self,
-                deserializer: D,
-            ) -> Result<Self::Value, D::Error> {
-                use std::os::fd::FromRawFd;
-                let raw = i32::deserialize(deserializer)?;
-                Ok(OsHandle::new(T::from(unsafe { OwnedFd::from_raw_fd(raw) })))
-            }
-        }
-
-        deserializer.deserialize_newtype_struct(OS_HANDLE_TYPE, Visitor(PhantomData))
+        crate::serde::deserialize_handle(deserializer).map(|handle| OsHandle::new(T::from(handle)))
     }
 }
 
 #[cfg(windows)]
 impl<T: AsHandle + Into<OwnedHandle>> ErasedHandle for OsHandle<T> {
-    fn raw_handle(&self) -> RawHandle {
-        let value = self
-            .0
-            .take()
-            .expect("operating-system handle was already consumed");
-        let raw = value.as_handle().as_raw_handle();
-        self.0.set(Some(value));
-        raw
-    }
-
-    fn steal_handle(&self) -> OwnedHandle {
-        self.0
-            .take()
-            .expect("operating-system handle was already consumed")
-            .into()
+    fn steal_handle(&self) -> Option<OwnedHandle> {
+        self.0.take().map(Into::into)
     }
 }
 
 #[cfg(windows)]
 impl<T: AsHandle + Into<OwnedHandle>> Serialize for OsHandle<T> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_newtype_struct(OS_HANDLE_TYPE, &HandleRef(self))
+        crate::serde::serialize_handle(self, serializer)
     }
 }
 
 #[cfg(windows)]
 impl<'de, T: From<OwnedHandle>> Deserialize<'de> for OsHandle<T> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        struct Visitor<T>(PhantomData<T>);
-
-        impl<'de, T: From<OwnedHandle>> de::Visitor<'de> for Visitor<T> {
-            type Value = OsHandle<T>;
-
-            fn expecting(&self, formatter: &mut Formatter<'_>) -> std::fmt::Result {
-                formatter.write_str("an operating-system handle")
-            }
-
-            fn visit_newtype_struct<D: Deserializer<'de>>(
-                self,
-                deserializer: D,
-            ) -> Result<Self::Value, D::Error> {
-                #[cfg(target_pointer_width = "32")]
-                let raw = u32::deserialize(deserializer)? as usize;
-                #[cfg(target_pointer_width = "64")]
-                let raw = u64::deserialize(deserializer)? as usize;
-                Ok(OsHandle::new(T::from(unsafe {
-                    OwnedHandle::from_raw_handle(raw as _)
-                })))
-            }
-        }
-
-        deserializer.deserialize_newtype_struct(OS_HANDLE_TYPE, Visitor(PhantomData))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    static SAME_TYPE_BYTES: [u8; 20] = *b"dolang_rpc::OsHandle";
-
-    #[test]
-    fn handle_type_uses_identity_not_contents() {
-        let same = unsafe { std::str::from_utf8_unchecked(&SAME_TYPE_BYTES) };
-        assert_eq!(same, OS_HANDLE_TYPE);
-        assert!(!std::ptr::eq(same, OS_HANDLE_TYPE));
+        crate::serde::deserialize_handle(deserializer).map(|handle| OsHandle::new(T::from(handle)))
     }
 }

--- a/dolang-rpc/src/serde.rs
+++ b/dolang-rpc/src/serde.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, io};
+use std::{any::TypeId, cell::RefCell, io};
 
 use ::serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use ::serde::{de::Error as _, ser::Error as _};
@@ -8,7 +8,7 @@ use postcard::ser_flavors::{ExtendFlavor, Flavor};
 use crate::{
     Error as RpcError,
     handle::{ErasedHandle, PutHandle, TakeHandle},
-    session::{self, Ref},
+    session::{self, Inner},
 };
 
 struct Context<T: ?Sized + 'static> {
@@ -135,7 +135,7 @@ pub(crate) fn decode_payload<T: de::DeserializeOwned>(
 }
 
 pub(crate) fn serialize_opaque<S: Serializer>(
-    opaque: &Ref,
+    opaque: &Inner,
     serializer: S,
 ) -> Result<S::Ok, S::Error> {
     let (owner, id) = access(&PUT, |handles| handles.put_opaque(opaque), encode_error)
@@ -143,13 +143,26 @@ pub(crate) fn serialize_opaque<S: Serializer>(
     serializer.serialize_u64(session::pack_wire(owner, id))
 }
 
-pub(crate) fn deserialize_opaque<'de, D: Deserializer<'de>>(
+pub(crate) fn deserialize_gift<'de, D: Deserializer<'de>>(
     deserializer: D,
-) -> Result<Ref, D::Error> {
+) -> Result<Inner, D::Error> {
     let (owner, id) = session::unpack_wire(u64::deserialize(deserializer)?);
     access(
         &TAKE,
-        |handles| handles.take_opaque(owner, id),
+        |handles| handles.take_gift(owner, id),
+        |message, _| RpcError::Deserialize(message),
+    )
+    .map_err(D::Error::custom)
+}
+
+pub(crate) fn deserialize_cite<'de, D: Deserializer<'de>>(
+    deserializer: D,
+    marker: TypeId,
+) -> Result<Inner, D::Error> {
+    let (owner, id) = session::unpack_wire(u64::deserialize(deserializer)?);
+    access(
+        &TAKE,
+        |handles| handles.take_cite(owner, id, marker),
         |message, _| RpcError::Deserialize(message),
     )
     .map_err(D::Error::custom)
@@ -232,7 +245,7 @@ mod tests {
             self.0.put_handle(handle)
         }
 
-        fn put_opaque(&mut self, _: &Ref) -> io::Result<(u8, u64)> {
+        fn put_opaque(&mut self, _: &Inner) -> io::Result<(u8, u64)> {
             unreachable!()
         }
     }
@@ -247,7 +260,11 @@ mod tests {
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid fd"))
         }
 
-        fn take_opaque(&mut self, _: u8, _: u64) -> io::Result<Ref> {
+        fn take_gift(&mut self, _: u8, _: u64) -> io::Result<Inner> {
+            unreachable!()
+        }
+
+        fn take_cite(&mut self, _: u8, _: u64, _: TypeId) -> io::Result<Inner> {
             unreachable!()
         }
     }

--- a/dolang-rpc/src/serde.rs
+++ b/dolang-rpc/src/serde.rs
@@ -1,1372 +1,318 @@
-#[cfg(unix)]
-use std::os::fd::IntoRawFd;
-#[cfg(windows)]
-use std::os::windows::io::IntoRawHandle;
-use std::{cell::RefCell, fmt, io, marker::PhantomData, ptr};
+use std::{cell::RefCell, io};
 
-use ::serde::{
-    Deserialize, Serialize,
-    de::{
-        self, DeserializeSeed, EnumAccess, IntoDeserializer, MapAccess, SeqAccess, VariantAccess,
-        Visitor,
-    },
-    ser::{self},
-};
+use ::serde::{Deserialize, Deserializer, Serialize, Serializer, de};
+use ::serde::{de::Error as _, ser::Error as _};
 use bytes::Bytes;
 use postcard::ser_flavors::{ExtendFlavor, Flavor};
 
 use crate::{
     Error as RpcError,
-    handle::{HandleRef, OS_HANDLE_TYPE, PutHandle, TakeHandle},
+    handle::{ErasedHandle, PutHandle, TakeHandle},
+    session::{self, Ref},
 };
 
-pub(crate) fn encode_payload<'handle, T: Serialize, H: PutHandle<'handle>>(
-    value: &'handle T,
-    handles: &mut H,
+struct Context<T: ?Sized + 'static> {
+    handles: &'static mut T,
+    error: &'static RefCell<Option<RpcError>>,
+}
+
+thread_local! {
+    static PUT: RefCell<Option<Context<dyn PutHandle>>> = const { RefCell::new(None) };
+    static TAKE: RefCell<Option<Context<dyn TakeHandle>>> = const { RefCell::new(None) };
+}
+
+struct Restore<'a, T: ?Sized + 'static> {
+    slot: &'a RefCell<Option<Context<T>>>,
+    value: Option<Context<T>>,
+}
+
+impl<T: ?Sized + 'static> Drop for Restore<'_, T> {
+    fn drop(&mut self) {
+        self.slot.replace(self.value.take());
+    }
+}
+
+fn scope<T: ?Sized + 'static, R>(
+    slot: &'static std::thread::LocalKey<RefCell<Option<Context<T>>>>,
+    handles: &'static mut T,
+    f: impl FnOnce() -> R,
+) -> (R, Option<RpcError>) {
+    let error = RefCell::new(None);
+    // SAFETY: the erased references are installed only for this synchronous
+    // call. `Restore` removes them on every return and unwind path, and access
+    // is confined to an immediately invoked closure that cannot return them.
+    let error_ref = unsafe {
+        std::mem::transmute::<&RefCell<Option<RpcError>>, &'static RefCell<Option<RpcError>>>(
+            &error,
+        )
+    };
+    let value = Context {
+        handles,
+        error: error_ref,
+    };
+    let result = slot.with(|slot| {
+        let previous = slot.replace(Some(value));
+        let _restore = Restore {
+            slot,
+            value: previous,
+        };
+        f()
+    });
+    (result, error.into_inner())
+}
+
+fn access<T: ?Sized + 'static, R>(
+    slot: &'static std::thread::LocalKey<RefCell<Option<Context<T>>>>,
+    f: impl FnOnce(&mut T) -> io::Result<R>,
+    map_error: impl FnOnce(String, io::ErrorKind) -> RpcError,
+) -> Result<R, String> {
+    slot.with(|slot| {
+        let current = slot
+            .replace(None)
+            .expect("RPC-only value used outside an RPC session");
+        let mut restore = Restore {
+            slot,
+            value: Some(current),
+        };
+        let context = restore.value.as_mut().unwrap();
+        match f(context.handles) {
+            Ok(value) => Ok(value),
+            Err(error) => {
+                let message = error.to_string();
+                let rpc_error = map_error(message.clone(), error.kind());
+                *context.error.borrow_mut() = Some(rpc_error);
+                Err(message)
+            }
+        }
+    })
+}
+
+pub(crate) fn encode_payload<T: Serialize>(
+    value: &T,
+    handles: &mut impl PutHandle,
 ) -> Result<Bytes, RpcError> {
-    let buffer = to_extend(value, handles, Vec::new()).map_err(|error| match error {
-        Error::UnsupportedCapability => RpcError::UnsupportedCapability,
-        error => RpcError::Serialize(error.to_string()),
-    })?;
-    Ok(buffer.into())
+    let handles: &mut dyn PutHandle = handles;
+    // SAFETY: `scope` removes this reference from TLS before returning.
+    let handles: &'static mut dyn PutHandle = unsafe { std::mem::transmute(handles) };
+    let (result, context_error) = scope(&PUT, handles, || {
+        let mut postcard = postcard::Serializer {
+            output: ExtendFlavor::new(Vec::new()),
+        };
+        value
+            .serialize(&mut postcard)
+            .and_then(|()| postcard.output.finalize())
+    });
+    match result {
+        Ok(bytes) => Ok(bytes.into()),
+        Err(error) => Err(context_error.unwrap_or_else(|| RpcError::Serialize(error.to_string()))),
+    }
 }
 
 pub(crate) fn decode_payload<T: de::DeserializeOwned>(
     bytes: &[u8],
     handles: &mut impl TakeHandle,
 ) -> Result<T, RpcError> {
-    let value = from_bytes(bytes, &mut *handles)
-        .map_err(|error| RpcError::Deserialize(error.to_string()))?;
-    if let Err(error) = handles.finish() {
-        drop(value);
-        return Err(RpcError::Deserialize(error.to_string()));
-    }
-    Ok(value)
-}
-
-#[derive(Debug, thiserror::Error)]
-pub(crate) enum Error {
-    #[error("postcard error: {0}")]
-    Postcard(#[from] postcard::Error),
-    #[error("{0}")]
-    Message(String),
-    /// A handle was serialized over a transport that cannot carry one.
-    #[error("transport does not support direct handles")]
-    UnsupportedCapability,
-}
-
-impl ser::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::Message(msg.to_string())
-    }
-}
-impl de::Error for Error {
-    fn custom<T: fmt::Display>(msg: T) -> Self {
-        Self::Message(msg.to_string())
-    }
-}
-
-// `Serializer`/`Deserializer` below use our own rich `Error` as their
-// associated error type throughout, so ordinary structural failures (a full
-// buffer, a malformed tag, ...) just convert via `Display` and nothing is
-// lost. But a handful of methods (`WithFrame::serialize`,
-// `SeedWrap::deserialize`, and the `VisitorWrap` methods that hand back a
-// fresh (de)serializer) are constrained by the external `serde` trait
-// signature that invokes them to return the *caller's* generic `S::Error`/
-// `D::Error` — ultimately postcard's own error type once the recursion
-// bottoms out. postcard's `custom` constructor for that type discards its
-// message and returns a fixed generic variant
-// (`SerdeSerCustom`/`SerdeDeCustom`), so a rich error can't just be converted
-// there. Instead we stash it on the `RefCell` threaded through the
-// (de)serialization context and raise a placeholder in its place;
-// `to_extend`/`from_bytes` prefer the stashed error over whatever
-// placeholder bubbles up through postcard.
-fn convert_ser_error<E: ser::Error>(err: E) -> Error {
-    Error::Message(err.to_string())
-}
-fn convert_de_error<E: de::Error>(err: E) -> Error {
-    Error::Message(err.to_string())
-}
-fn stash_ser_error<E: ser::Error>(slot: &RefCell<Option<Error>>, err: Error) -> E {
-    let message = err.to_string();
-    *slot.borrow_mut() = Some(err);
-    E::custom(message)
-}
-fn stash_de_error<E: de::Error>(slot: &RefCell<Option<Error>>, err: Error) -> E {
-    let message = err.to_string();
-    *slot.borrow_mut() = Some(err);
-    E::custom(message)
-}
-
-pub(crate) fn to_extend<'frame, T, F>(
-    value: &'frame T,
-    frame: &mut F,
-    output: Vec<u8>,
-) -> Result<Vec<u8>, Error>
-where
-    T: Serialize + ?Sized,
-    F: PutHandle<'frame>,
-{
-    let mut postcard = postcard::Serializer {
-        output: ExtendFlavor::new(output),
-    };
-    let frame = RefCell::new(frame);
-    let error = RefCell::new(None);
-    if let Err(err) = value.serialize(Serializer {
-        inner: &mut postcard,
-        frame: &frame,
-        error: &error,
-        marker: PhantomData,
-    }) {
-        return Err(error.into_inner().unwrap_or(err));
-    }
-    Ok(postcard.output.finalize()?)
-}
-
-pub(crate) fn from_bytes<'de, T, H>(bytes: &'de [u8], handles: &mut H) -> Result<T, Error>
-where
-    T: Deserialize<'de>,
-    H: TakeHandle,
-{
-    let mut postcard = postcard::Deserializer::from_bytes(bytes);
-    let error = RefCell::new(None);
-    let value = match T::deserialize(Deserializer {
-        inner: &mut postcard,
-        handles,
-        error: &error,
-    }) {
-        Ok(value) => value,
-        Err(err) => return Err(error.into_inner().unwrap_or(err)),
-    };
-    let remaining = postcard.finalize()?;
-    if !remaining.is_empty() {
-        return Err(Error::Message("trailing bytes in payload".into()));
-    }
-    Ok(value)
-}
-
-struct Serializer<'cell, 'borrow, 'frame, S, F> {
-    inner: S,
-    frame: &'cell RefCell<&'borrow mut F>,
-    error: &'cell RefCell<Option<Error>>,
-    marker: PhantomData<&'frame ()>,
-}
-struct WithFrame<'value, 'cell, 'borrow, 'frame, T: ?Sized, F> {
-    value: &'value T,
-    frame: &'cell RefCell<&'borrow mut F>,
-    error: &'cell RefCell<Option<Error>>,
-    marker: PhantomData<&'frame ()>,
-}
-struct Compound<'cell, 'borrow, 'frame, C, F> {
-    inner: C,
-    frame: &'cell RefCell<&'borrow mut F>,
-    error: &'cell RefCell<Option<Error>>,
-    marker: PhantomData<&'frame ()>,
-}
-
-impl<'frame, T: Serialize + ?Sized, F: PutHandle<'frame>> Serialize
-    for WithFrame<'_, '_, '_, 'frame, T, F>
-{
-    fn serialize<S: ser::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        self.value
-            .serialize(Serializer {
-                inner: serializer,
-                frame: self.frame,
-                error: self.error,
-                marker: PhantomData,
-            })
-            .map_err(|err| stash_ser_error(self.error, err))
-    }
-}
-
-macro_rules! forward_ser {
-    ($($name:ident($ty:ty)),* $(,)?) => {$(
-        fn $name(self, value: $ty) -> Result<Self::Ok, Self::Error> {
-            self.inner.$name(value).map_err(convert_ser_error)
+    let handles: &mut dyn TakeHandle = handles;
+    // SAFETY: `scope` removes this reference from TLS before returning.
+    let scoped_handles: &'static mut dyn TakeHandle = unsafe { std::mem::transmute(handles) };
+    let (result, context_error) = scope(&TAKE, scoped_handles, || {
+        let mut postcard = postcard::Deserializer::from_bytes(bytes);
+        let value = T::deserialize(&mut postcard)?;
+        let remaining = postcard.finalize()?;
+        if !remaining.is_empty() {
+            return Err(postcard::Error::DeserializeBadEncoding);
         }
-    )*};
-}
-
-impl<'cell, 'borrow, 'frame, S, F> ser::Serializer for Serializer<'cell, 'borrow, 'frame, S, F>
-where
-    F: PutHandle<'frame>,
-    S: ser::Serializer,
-{
-    type Ok = S::Ok;
-    type Error = Error;
-    type SerializeSeq = Compound<'cell, 'borrow, 'frame, S::SerializeSeq, F>;
-    type SerializeTuple = Compound<'cell, 'borrow, 'frame, S::SerializeTuple, F>;
-    type SerializeTupleStruct = Compound<'cell, 'borrow, 'frame, S::SerializeTupleStruct, F>;
-    type SerializeTupleVariant = Compound<'cell, 'borrow, 'frame, S::SerializeTupleVariant, F>;
-    type SerializeMap = Compound<'cell, 'borrow, 'frame, S::SerializeMap, F>;
-    type SerializeStruct = Compound<'cell, 'borrow, 'frame, S::SerializeStruct, F>;
-    type SerializeStructVariant = Compound<'cell, 'borrow, 'frame, S::SerializeStructVariant, F>;
-
-    forward_ser!(
-        serialize_bool(bool),
-        serialize_i8(i8),
-        serialize_i16(i16),
-        serialize_i32(i32),
-        serialize_i64(i64),
-        serialize_i128(i128),
-        serialize_u8(u8),
-        serialize_u16(u16),
-        serialize_u32(u32),
-        serialize_u64(u64),
-        serialize_u128(u128),
-        serialize_f32(f32),
-        serialize_f64(f64),
-        serialize_char(char)
-    );
-    fn serialize_str(self, v: &str) -> Result<Self::Ok, Self::Error> {
-        self.inner.serialize_str(v).map_err(convert_ser_error)
-    }
-    fn serialize_bytes(self, v: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.inner.serialize_bytes(v).map_err(convert_ser_error)
-    }
-    fn serialize_none(self) -> Result<Self::Ok, Self::Error> {
-        self.inner.serialize_none().map_err(convert_ser_error)
-    }
-    fn serialize_some<T: ?Sized + Serialize>(self, value: &T) -> Result<Self::Ok, Self::Error> {
-        self.inner
-            .serialize_some(&WithFrame {
-                value,
-                frame: self.frame,
-                error: self.error,
-                marker: PhantomData,
-            })
-            .map_err(convert_ser_error)
-    }
-    fn serialize_unit(self) -> Result<Self::Ok, Self::Error> {
-        self.inner.serialize_unit().map_err(convert_ser_error)
-    }
-    fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok, Self::Error> {
-        self.inner
-            .serialize_unit_struct(name)
-            .map_err(convert_ser_error)
-    }
-    fn serialize_unit_variant(
-        self,
-        name: &'static str,
-        index: u32,
-        variant: &'static str,
-    ) -> Result<Self::Ok, Self::Error> {
-        self.inner
-            .serialize_unit_variant(name, index, variant)
-            .map_err(convert_ser_error)
-    }
-    fn serialize_newtype_struct<T: ?Sized + Serialize>(
-        self,
-        name: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok, Self::Error> {
-        if ptr::eq(name, OS_HANDLE_TYPE) {
-            let raw = value.serialize(RawHandleSerializer)?;
-            // SAFETY: only `OsHandle::serialize` can supply the private marker
-            // by identity. It passes a live `HandleRef` whose referent belongs
-            // to the message borrowed for `'frame`.
-            let handle = unsafe { (*(raw as *const HandleRef<'frame>)).0 };
-            let value = self.frame.borrow_mut().put_handle(handle).map_err(|err| {
-                if err.kind() == io::ErrorKind::Unsupported {
-                    Error::UnsupportedCapability
-                } else {
-                    Error::Message(err.to_string())
-                }
-            })?;
-            #[cfg(unix)]
-            return self.inner.serialize_u32(value).map_err(convert_ser_error);
-            #[cfg(all(windows, target_pointer_width = "32"))]
-            return self
-                .inner
-                .serialize_u32(value as u32)
-                .map_err(convert_ser_error);
-            #[cfg(all(windows, target_pointer_width = "64"))]
-            return self
-                .inner
-                .serialize_u64(value as u64)
-                .map_err(convert_ser_error);
-        }
-        self.inner
-            .serialize_newtype_struct(
-                name,
-                &WithFrame {
-                    value,
-                    frame: self.frame,
-                    error: self.error,
-                    marker: PhantomData,
-                },
-            )
-            .map_err(convert_ser_error)
-    }
-    fn serialize_newtype_variant<T: ?Sized + Serialize>(
-        self,
-        name: &'static str,
-        index: u32,
-        variant: &'static str,
-        value: &T,
-    ) -> Result<Self::Ok, Self::Error> {
-        self.inner
-            .serialize_newtype_variant(
-                name,
-                index,
-                variant,
-                &WithFrame {
-                    value,
-                    frame: self.frame,
-                    error: self.error,
-                    marker: PhantomData,
-                },
-            )
-            .map_err(convert_ser_error)
-    }
-    fn serialize_seq(self, len: Option<usize>) -> Result<Self::SerializeSeq, Self::Error> {
-        Ok(Compound {
-            inner: self.inner.serialize_seq(len).map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn serialize_tuple(self, len: usize) -> Result<Self::SerializeTuple, Self::Error> {
-        Ok(Compound {
-            inner: self.inner.serialize_tuple(len).map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn serialize_tuple_struct(
-        self,
-        name: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeTupleStruct, Self::Error> {
-        Ok(Compound {
-            inner: self
-                .inner
-                .serialize_tuple_struct(name, len)
-                .map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn serialize_tuple_variant(
-        self,
-        name: &'static str,
-        index: u32,
-        variant: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeTupleVariant, Self::Error> {
-        Ok(Compound {
-            inner: self
-                .inner
-                .serialize_tuple_variant(name, index, variant, len)
-                .map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn serialize_map(self, len: Option<usize>) -> Result<Self::SerializeMap, Self::Error> {
-        Ok(Compound {
-            inner: self.inner.serialize_map(len).map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn serialize_struct(
-        self,
-        name: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeStruct, Self::Error> {
-        Ok(Compound {
-            inner: self
-                .inner
-                .serialize_struct(name, len)
-                .map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn serialize_struct_variant(
-        self,
-        name: &'static str,
-        index: u32,
-        variant: &'static str,
-        len: usize,
-    ) -> Result<Self::SerializeStructVariant, Self::Error> {
-        Ok(Compound {
-            inner: self
-                .inner
-                .serialize_struct_variant(name, index, variant, len)
-                .map_err(convert_ser_error)?,
-            frame: self.frame,
-            error: self.error,
-            marker: PhantomData,
-        })
-    }
-    fn collect_str<T: ?Sized + fmt::Display>(self, value: &T) -> Result<Self::Ok, Self::Error> {
-        self.inner.collect_str(value).map_err(convert_ser_error)
-    }
-    fn is_human_readable(&self) -> bool {
-        self.inner.is_human_readable()
-    }
-}
-
-macro_rules! compound {
-    ($trait:ident,$method:ident) => {
-        impl<'frame, C: ser::$trait, F: PutHandle<'frame>> ser::$trait
-            for Compound<'_, '_, 'frame, C, F>
-        {
-            type Ok = C::Ok;
-            type Error = Error;
-            fn $method<T: ?Sized + Serialize>(&mut self, value: &T) -> Result<(), Self::Error> {
-                self.inner
-                    .$method(&WithFrame {
-                        value,
-                        frame: self.frame,
-                        error: self.error,
-                        marker: PhantomData,
-                    })
-                    .map_err(convert_ser_error)
-            }
-            fn end(self) -> Result<Self::Ok, Self::Error> {
-                self.inner.end().map_err(convert_ser_error)
-            }
-        }
-    };
-}
-compound!(SerializeSeq, serialize_element);
-compound!(SerializeTuple, serialize_element);
-compound!(SerializeTupleStruct, serialize_field);
-compound!(SerializeTupleVariant, serialize_field);
-impl<'frame, C: ser::SerializeMap, F: PutHandle<'frame>> ser::SerializeMap
-    for Compound<'_, '_, 'frame, C, F>
-{
-    type Ok = C::Ok;
-    type Error = Error;
-    fn serialize_key<T: ?Sized + Serialize>(&mut self, v: &T) -> Result<(), Self::Error> {
-        self.inner
-            .serialize_key(&WithFrame {
-                value: v,
-                frame: self.frame,
-                error: self.error,
-                marker: PhantomData,
-            })
-            .map_err(convert_ser_error)
-    }
-    fn serialize_value<T: ?Sized + Serialize>(&mut self, v: &T) -> Result<(), Self::Error> {
-        self.inner
-            .serialize_value(&WithFrame {
-                value: v,
-                frame: self.frame,
-                error: self.error,
-                marker: PhantomData,
-            })
-            .map_err(convert_ser_error)
-    }
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.inner.end().map_err(convert_ser_error)
-    }
-}
-impl<'frame, C: ser::SerializeStruct, F: PutHandle<'frame>> ser::SerializeStruct
-    for Compound<'_, '_, 'frame, C, F>
-{
-    type Ok = C::Ok;
-    type Error = Error;
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        key: &'static str,
-        v: &T,
-    ) -> Result<(), Self::Error> {
-        self.inner
-            .serialize_field(
-                key,
-                &WithFrame {
-                    value: v,
-                    frame: self.frame,
-                    error: self.error,
-                    marker: PhantomData,
-                },
-            )
-            .map_err(convert_ser_error)
-    }
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.inner.end().map_err(convert_ser_error)
-    }
-}
-impl<'frame, C: ser::SerializeStructVariant, F: PutHandle<'frame>> ser::SerializeStructVariant
-    for Compound<'_, '_, 'frame, C, F>
-{
-    type Ok = C::Ok;
-    type Error = Error;
-    fn serialize_field<T: ?Sized + Serialize>(
-        &mut self,
-        key: &'static str,
-        v: &T,
-    ) -> Result<(), Self::Error> {
-        self.inner
-            .serialize_field(
-                key,
-                &WithFrame {
-                    value: v,
-                    frame: self.frame,
-                    error: self.error,
-                    marker: PhantomData,
-                },
-            )
-            .map_err(convert_ser_error)
-    }
-    fn end(self) -> Result<Self::Ok, Self::Error> {
-        self.inner.end().map_err(convert_ser_error)
-    }
-}
-
-struct RawHandleSerializer;
-
-impl ser::Serializer for RawHandleSerializer {
-    type Ok = usize;
-    type Error = Error;
-    type SerializeSeq = ser::Impossible<usize, Error>;
-    type SerializeTuple = Self::SerializeSeq;
-    type SerializeTupleStruct = Self::SerializeSeq;
-    type SerializeTupleVariant = Self::SerializeSeq;
-    type SerializeMap = Self::SerializeSeq;
-    type SerializeStruct = Self::SerializeSeq;
-    type SerializeStructVariant = Self::SerializeSeq;
-    fn serialize_i32(self, v: i32) -> Result<usize, Error> {
-        let _ = v;
-        #[cfg(unix)]
-        return Ok(v as usize);
-        #[cfg(windows)]
-        return raw_error();
-    }
-    fn is_human_readable(&self) -> bool {
-        false
-    }
-    fn serialize_bool(self, _: bool) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_i8(self, _: i8) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_i16(self, _: i16) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_i64(self, _: i64) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_i128(self, _: i128) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_u8(self, _: u8) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_u16(self, _: u16) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_u32(self, v: u32) -> Result<usize, Error> {
-        let _ = v;
-        #[cfg(target_pointer_width = "32")]
-        return Ok(v as usize);
-        #[cfg(not(target_pointer_width = "32"))]
-        return raw_error();
-    }
-    fn serialize_u64(self, v: u64) -> Result<usize, Error> {
-        let _ = v;
-        #[cfg(target_pointer_width = "64")]
-        return Ok(v as usize);
-        #[cfg(not(target_pointer_width = "64"))]
-        return raw_error();
-    }
-    fn serialize_u128(self, _: u128) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_f32(self, _: f32) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_f64(self, _: f64) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_char(self, _: char) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_str(self, _: &str) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_bytes(self, _: &[u8]) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_none(self) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_some<T: ?Sized + Serialize>(self, _: &T) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_unit(self) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_unit_struct(self, _: &'static str) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_unit_variant(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-    ) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_newtype_struct<T: ?Sized + Serialize>(
-        self,
-        _: &'static str,
-        _: &T,
-    ) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_newtype_variant<T: ?Sized + Serialize>(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: &T,
-    ) -> Result<usize, Error> {
-        raw_error()
-    }
-    fn serialize_seq(self, _: Option<usize>) -> Result<Self::SerializeSeq, Error> {
-        raw_error()
-    }
-    fn serialize_tuple(self, _: usize) -> Result<Self::SerializeTuple, Error> {
-        raw_error()
-    }
-    fn serialize_tuple_struct(
-        self,
-        _: &'static str,
-        _: usize,
-    ) -> Result<Self::SerializeTupleStruct, Error> {
-        raw_error()
-    }
-    fn serialize_tuple_variant(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: usize,
-    ) -> Result<Self::SerializeTupleVariant, Error> {
-        raw_error()
-    }
-    fn serialize_map(self, _: Option<usize>) -> Result<Self::SerializeMap, Error> {
-        raw_error()
-    }
-    fn serialize_struct(self, _: &'static str, _: usize) -> Result<Self::SerializeStruct, Error> {
-        raw_error()
-    }
-    fn serialize_struct_variant(
-        self,
-        _: &'static str,
-        _: u32,
-        _: &'static str,
-        _: usize,
-    ) -> Result<Self::SerializeStructVariant, Error> {
-        raw_error()
-    }
-}
-
-fn raw_error<T>() -> Result<T, Error> {
-    Err(Error::Message("invalid OsHandle representation".into()))
-}
-
-struct Deserializer<'a, D, H> {
-    inner: D,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-struct VisitorWrap<'a, V, H> {
-    inner: V,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-struct SeedWrap<'a, S, H> {
-    inner: S,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-struct SeqWrap<'a, A, H> {
-    inner: A,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-struct MapWrap<'a, A, H> {
-    inner: A,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-struct EnumWrap<'a, A, H> {
-    inner: A,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-struct VariantWrap<'a, A, H> {
-    inner: A,
-    handles: &'a mut H,
-    error: &'a RefCell<Option<Error>>,
-}
-
-macro_rules! forward_de {
-    ($($method:ident),* $(,)?) => {$(
-        fn $method<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
-            self.inner
-                .$method(VisitorWrap { inner: visitor, handles: self.handles, error: self.error })
-                .map_err(convert_de_error)
-        }
-    )*};
-}
-
-impl<'de, D, H> de::Deserializer<'de> for Deserializer<'_, D, H>
-where
-    D: de::Deserializer<'de>,
-    H: TakeHandle,
-{
-    type Error = Error;
-    forward_de!(
-        deserialize_any,
-        deserialize_bool,
-        deserialize_i8,
-        deserialize_i16,
-        deserialize_i32,
-        deserialize_i64,
-        deserialize_i128,
-        deserialize_u8,
-        deserialize_u16,
-        deserialize_u32,
-        deserialize_u64,
-        deserialize_u128,
-        deserialize_f32,
-        deserialize_f64,
-        deserialize_char,
-        deserialize_str,
-        deserialize_string,
-        deserialize_bytes,
-        deserialize_byte_buf,
-        deserialize_option,
-        deserialize_unit,
-        deserialize_seq,
-        deserialize_map,
-        deserialize_identifier,
-        deserialize_ignored_any
-    );
-    fn deserialize_unit_struct<V: Visitor<'de>>(
-        self,
-        name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        self.inner
-            .deserialize_unit_struct(
-                name,
-                VisitorWrap {
-                    inner: visitor,
-                    handles: self.handles,
-                    error: self.error,
-                },
-            )
-            .map_err(convert_de_error)
-    }
-    fn deserialize_newtype_struct<V: Visitor<'de>>(
-        self,
-        name: &'static str,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        if ptr::eq(name, OS_HANDLE_TYPE) {
-            #[cfg(unix)]
-            {
-                let index = u32::deserialize(self.inner).map_err(convert_de_error)?;
-                let fd = self
-                    .handles
-                    .take_handle(index)
-                    .map_err(|err| Error::Message(err.to_string()))?;
-                // The private OsHandle visitor immediately adopts this raw fd.
-                // No other visitor can request the reserved newtype identity.
-                let raw = fd.into_raw_fd();
-                return visitor
-                    .visit_newtype_struct(IntoDeserializer::<Error>::into_deserializer(raw))
-                    .map_err(convert_de_error);
-            }
-            #[cfg(windows)]
-            {
-                #[cfg(target_pointer_width = "32")]
-                let value = u32::deserialize(self.inner).map_err(convert_de_error)? as usize;
-                #[cfg(target_pointer_width = "64")]
-                let value = u64::deserialize(self.inner).map_err(convert_de_error)? as usize;
-                let handle = self
-                    .handles
-                    .take_handle(value)
-                    .map_err(|err| Error::Message(err.to_string()))?;
-                let raw = handle.into_raw_handle() as usize;
-                #[cfg(target_pointer_width = "32")]
-                return visitor
-                    .visit_newtype_struct(IntoDeserializer::<Error>::into_deserializer(raw as u32))
-                    .map_err(convert_de_error);
-                #[cfg(target_pointer_width = "64")]
-                return visitor
-                    .visit_newtype_struct(IntoDeserializer::<Error>::into_deserializer(raw as u64))
-                    .map_err(convert_de_error);
-            }
-        }
-        self.inner
-            .deserialize_newtype_struct(
-                name,
-                VisitorWrap {
-                    inner: visitor,
-                    handles: self.handles,
-                    error: self.error,
-                },
-            )
-            .map_err(convert_de_error)
-    }
-    fn deserialize_tuple<V: Visitor<'de>>(
-        self,
-        len: usize,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        self.inner
-            .deserialize_tuple(
-                len,
-                VisitorWrap {
-                    inner: visitor,
-                    handles: self.handles,
-                    error: self.error,
-                },
-            )
-            .map_err(convert_de_error)
-    }
-    fn deserialize_tuple_struct<V: Visitor<'de>>(
-        self,
-        name: &'static str,
-        len: usize,
-        visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        self.inner
-            .deserialize_tuple_struct(
-                name,
-                len,
-                VisitorWrap {
-                    inner: visitor,
-                    handles: self.handles,
-                    error: self.error,
-                },
-            )
-            .map_err(convert_de_error)
-    }
-    fn deserialize_struct<V: Visitor<'de>>(
-        self,
-        name: &'static str,
-        fields: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        self.inner
-            .deserialize_struct(
-                name,
-                fields,
-                VisitorWrap {
-                    inner: visitor,
-                    handles: self.handles,
-                    error: self.error,
-                },
-            )
-            .map_err(convert_de_error)
-    }
-    fn deserialize_enum<V: Visitor<'de>>(
-        self,
-        name: &'static str,
-        variants: &'static [&'static str],
-        visitor: V,
-    ) -> Result<V::Value, Self::Error> {
-        self.inner
-            .deserialize_enum(
-                name,
-                variants,
-                VisitorWrap {
-                    inner: visitor,
-                    handles: self.handles,
-                    error: self.error,
-                },
-            )
-            .map_err(convert_de_error)
-    }
-    fn is_human_readable(&self) -> bool {
-        false
-    }
-}
-
-impl<'de, S, H> DeserializeSeed<'de> for SeedWrap<'_, S, H>
-where
-    S: DeserializeSeed<'de>,
-    H: TakeHandle,
-{
-    type Value = S::Value;
-    fn deserialize<D: de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
-        self.inner
-            .deserialize(Deserializer {
-                inner: d,
-                handles: self.handles,
-                error: self.error,
-            })
-            .map_err(|err| stash_de_error(self.error, err))
-    }
-}
-
-macro_rules! visit_scalar { ($($name:ident($ty:ty)),* $(,)?) => {$(
- fn $name<E:de::Error>(self,v:$ty)->Result<Self::Value,E>{self.inner.$name(v)}
- )*}; }
-impl<'de, V: Visitor<'de>, H: TakeHandle> Visitor<'de> for VisitorWrap<'_, V, H> {
-    type Value = V::Value;
-    fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        self.inner.expecting(f)
-    }
-    visit_scalar!(
-        visit_bool(bool),
-        visit_i8(i8),
-        visit_i16(i16),
-        visit_i32(i32),
-        visit_i64(i64),
-        visit_i128(i128),
-        visit_u8(u8),
-        visit_u16(u16),
-        visit_u32(u32),
-        visit_u64(u64),
-        visit_u128(u128),
-        visit_f32(f32),
-        visit_f64(f64),
-        visit_char(char)
-    );
-    fn visit_str<E: de::Error>(self, v: &str) -> Result<Self::Value, E> {
-        self.inner.visit_str(v)
-    }
-    fn visit_borrowed_str<E: de::Error>(self, v: &'de str) -> Result<Self::Value, E> {
-        self.inner.visit_borrowed_str(v)
-    }
-    fn visit_string<E: de::Error>(self, v: String) -> Result<Self::Value, E> {
-        self.inner.visit_string(v)
-    }
-    fn visit_bytes<E: de::Error>(self, v: &[u8]) -> Result<Self::Value, E> {
-        self.inner.visit_bytes(v)
-    }
-    fn visit_borrowed_bytes<E: de::Error>(self, v: &'de [u8]) -> Result<Self::Value, E> {
-        self.inner.visit_borrowed_bytes(v)
-    }
-    fn visit_byte_buf<E: de::Error>(self, v: Vec<u8>) -> Result<Self::Value, E> {
-        self.inner.visit_byte_buf(v)
-    }
-    fn visit_none<E: de::Error>(self) -> Result<Self::Value, E> {
-        self.inner.visit_none()
-    }
-    fn visit_some<D: de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
-        self.inner
-            .visit_some(Deserializer {
-                inner: d,
-                handles: self.handles,
-                error: self.error,
-            })
-            .map_err(|err| stash_de_error(self.error, err))
-    }
-    fn visit_unit<E: de::Error>(self) -> Result<Self::Value, E> {
-        self.inner.visit_unit()
-    }
-    fn visit_newtype_struct<D: de::Deserializer<'de>>(self, d: D) -> Result<Self::Value, D::Error> {
-        self.inner
-            .visit_newtype_struct(Deserializer {
-                inner: d,
-                handles: self.handles,
-                error: self.error,
-            })
-            .map_err(|err| stash_de_error(self.error, err))
-    }
-    fn visit_seq<A: SeqAccess<'de>>(self, a: A) -> Result<Self::Value, A::Error> {
-        self.inner.visit_seq(SeqWrap {
-            inner: a,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-    fn visit_map<A: MapAccess<'de>>(self, a: A) -> Result<Self::Value, A::Error> {
-        self.inner.visit_map(MapWrap {
-            inner: a,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-    fn visit_enum<A: EnumAccess<'de>>(self, a: A) -> Result<Self::Value, A::Error> {
-        self.inner.visit_enum(EnumWrap {
-            inner: a,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-}
-impl<'de, A: SeqAccess<'de>, H: TakeHandle> SeqAccess<'de> for SeqWrap<'_, A, H> {
-    type Error = A::Error;
-    fn next_element_seed<T: DeserializeSeed<'de>>(
-        &mut self,
-        seed: T,
-    ) -> Result<Option<T::Value>, A::Error> {
-        self.inner.next_element_seed(SeedWrap {
-            inner: seed,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-    fn size_hint(&self) -> Option<usize> {
-        self.inner.size_hint()
-    }
-}
-impl<'de, A: MapAccess<'de>, H: TakeHandle> MapAccess<'de> for MapWrap<'_, A, H> {
-    type Error = A::Error;
-    fn next_key_seed<K: DeserializeSeed<'de>>(
-        &mut self,
-        seed: K,
-    ) -> Result<Option<K::Value>, A::Error> {
-        self.inner.next_key_seed(SeedWrap {
-            inner: seed,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-    fn next_value_seed<V: DeserializeSeed<'de>>(&mut self, seed: V) -> Result<V::Value, A::Error> {
-        self.inner.next_value_seed(SeedWrap {
-            inner: seed,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-    fn size_hint(&self) -> Option<usize> {
-        self.inner.size_hint()
-    }
-}
-impl<'a, 'de, A: EnumAccess<'de>, H: TakeHandle> EnumAccess<'de> for EnumWrap<'a, A, H> {
-    type Error = A::Error;
-    type Variant = VariantWrap<'a, A::Variant, H>;
-    fn variant_seed<V: DeserializeSeed<'de>>(
-        self,
-        seed: V,
-    ) -> Result<(V::Value, Self::Variant), A::Error> {
-        let (v, a) = self.inner.variant_seed(SeedWrap {
-            inner: seed,
-            handles: self.handles,
-            error: self.error,
-        })?;
-        Ok((
-            v,
-            VariantWrap {
-                inner: a,
-                handles: self.handles,
-                error: self.error,
-            },
-        ))
-    }
-}
-impl<'de, A: VariantAccess<'de>, H: TakeHandle> VariantAccess<'de> for VariantWrap<'_, A, H> {
-    type Error = A::Error;
-    fn unit_variant(self) -> Result<(), A::Error> {
-        self.inner.unit_variant()
-    }
-    fn newtype_variant_seed<T: DeserializeSeed<'de>>(self, seed: T) -> Result<T::Value, A::Error> {
-        self.inner.newtype_variant_seed(SeedWrap {
-            inner: seed,
-            handles: self.handles,
-            error: self.error,
-        })
-    }
-    fn tuple_variant<V: Visitor<'de>>(self, len: usize, v: V) -> Result<V::Value, A::Error> {
-        self.inner.tuple_variant(
-            len,
-            VisitorWrap {
-                inner: v,
-                handles: self.handles,
-                error: self.error,
-            },
+        access(
+            &TAKE,
+            |handles| handles.finish(),
+            |message, _| RpcError::Deserialize(message),
         )
-    }
-    fn struct_variant<V: Visitor<'de>>(
-        self,
-        fields: &'static [&'static str],
-        v: V,
-    ) -> Result<V::Value, A::Error> {
-        self.inner.struct_variant(
-            fields,
-            VisitorWrap {
-                inner: v,
-                handles: self.handles,
-                error: self.error,
-            },
-        )
+        .map_err(|_| postcard::Error::SerdeDeCustom)?;
+        Ok(value)
+    });
+    result
+        .map_err(|error| context_error.unwrap_or_else(|| RpcError::Deserialize(error.to_string())))
+}
+
+pub(crate) fn serialize_opaque<S: Serializer>(
+    opaque: &Ref,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let (owner, id) = access(&PUT, |handles| handles.put_opaque(opaque), encode_error)
+        .map_err(S::Error::custom)?;
+    serializer.serialize_u64(session::pack_wire(owner, id))
+}
+
+pub(crate) fn deserialize_opaque<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Ref, D::Error> {
+    let (owner, id) = session::unpack_wire(u64::deserialize(deserializer)?);
+    access(
+        &TAKE,
+        |handles| handles.take_opaque(owner, id),
+        |message, _| RpcError::Deserialize(message),
+    )
+    .map_err(D::Error::custom)
+}
+
+#[cfg(unix)]
+pub(crate) fn serialize_handle<S: Serializer>(
+    handle: &dyn ErasedHandle,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let index = access(&PUT, |handles| handles.put_handle(handle), encode_error)
+        .map_err(S::Error::custom)?;
+    serializer.serialize_u32(index)
+}
+
+#[cfg(unix)]
+pub(crate) fn deserialize_handle<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<std::os::fd::OwnedFd, D::Error> {
+    let index = u32::deserialize(deserializer)?;
+    access(
+        &TAKE,
+        |handles| handles.take_handle(index),
+        |message, _| RpcError::Deserialize(message),
+    )
+    .map_err(D::Error::custom)
+}
+
+#[cfg(windows)]
+pub(crate) fn serialize_handle<S: Serializer>(
+    handle: &dyn ErasedHandle,
+    serializer: S,
+) -> Result<S::Ok, S::Error> {
+    let value = access(&PUT, |handles| handles.put_handle(handle), encode_error)
+        .map_err(S::Error::custom)?;
+    #[cfg(target_pointer_width = "32")]
+    return serializer.serialize_u32(value as u32);
+    #[cfg(target_pointer_width = "64")]
+    return serializer.serialize_u64(value as u64);
+}
+
+#[cfg(windows)]
+pub(crate) fn deserialize_handle<'de, D: Deserializer<'de>>(
+    deserializer: D,
+) -> Result<std::os::windows::io::OwnedHandle, D::Error> {
+    #[cfg(target_pointer_width = "32")]
+    let value = u32::deserialize(deserializer)? as usize;
+    #[cfg(target_pointer_width = "64")]
+    let value = u64::deserialize(deserializer)? as usize;
+    access(
+        &TAKE,
+        |handles| handles.take_handle(value),
+        |message, _| RpcError::Deserialize(message),
+    )
+    .map_err(D::Error::custom)
+}
+
+fn encode_error(message: String, kind: io::ErrorKind) -> RpcError {
+    if kind == io::ErrorKind::Unsupported {
+        RpcError::UnsupportedCapability
+    } else {
+        RpcError::Serialize(message)
     }
 }
 
 #[cfg(all(test, unix))]
 mod tests {
-    use super::*;
-    use crate::{handle::OsHandle, transport::EncodeHandles};
-    use ::serde::{Deserialize, Serialize, ser::SerializeStruct};
-    use nix::unistd::pipe;
-    use std::io;
     use std::os::fd::OwnedFd;
 
-    struct Frame(Vec<i32>);
-    impl<'a> PutHandle<'a> for Frame {
-        fn put_handle(&mut self, _fd: &'a dyn crate::handle::ErasedHandle) -> io::Result<u32> {
-            let index = self.0.len() as u32;
-            self.0.push(index as i32);
-            Ok(index)
+    use nix::unistd::pipe;
+    use serde::{Deserialize, Serialize};
+
+    use super::*;
+    use crate::{handle::OsHandle, transport::EncodeHandles};
+
+    struct Sender(EncodeHandles);
+
+    impl PutHandle for Sender {
+        fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<u32> {
+            self.0.put_handle(handle)
+        }
+
+        fn put_opaque(&mut self, _: &Ref) -> io::Result<(u8, u64)> {
+            unreachable!()
         }
     }
 
-    struct TestReceiver(Vec<Option<OwnedFd>>);
-    impl TakeHandle for TestReceiver {
+    struct Receiver(Vec<Option<OwnedFd>>);
+
+    impl TakeHandle for Receiver {
         fn take_handle(&mut self, index: u32) -> io::Result<OwnedFd> {
             self.0
                 .get_mut(index as usize)
                 .and_then(Option::take)
                 .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidData, "invalid fd"))
         }
-    }
 
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    enum Ordinary {
-        Unit,
-        Tuple(u32, String),
-        Struct { values: Vec<u8> },
-    }
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Newtype(u64);
-
-    #[derive(Debug, PartialEq, Serialize, Deserialize)]
-    struct Compatibility {
-        some: Option<Newtype>,
-        none: Option<u8>,
-        map: std::collections::BTreeMap<String, Ordinary>,
-        variants: Vec<Ordinary>,
-    }
-
-    #[derive(Serialize)]
-    struct OneHandle<'a> {
-        handle: &'a OsHandle<OwnedFd>,
-    }
-
-    #[derive(Serialize)]
-    struct RepeatedHandle<'a> {
-        first: &'a OsHandle<OwnedFd>,
-        second: &'a OsHandle<OwnedFd>,
-    }
-
-    struct FailsAfterHandle<'a>(&'a OsHandle<OwnedFd>);
-
-    impl Serialize for FailsAfterHandle<'_> {
-        fn serialize<S: ::serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-            let mut state = serializer.serialize_struct("FailsAfterHandle", 2)?;
-            state.serialize_field("handle", self.0)?;
-            Err(::serde::ser::Error::custom("intentional failure"))
+        fn take_opaque(&mut self, _: u8, _: u64) -> io::Result<Ref> {
+            unreachable!()
         }
     }
 
-    #[derive(Debug)]
-    struct AlwaysFailsToDeserialize;
-
-    impl<'de> Deserialize<'de> for AlwaysFailsToDeserialize {
-        fn deserialize<D: ::serde::Deserializer<'de>>(_d: D) -> Result<Self, D::Error> {
-            Err(::serde::de::Error::custom(
-                "intentional deserialize failure",
-            ))
-        }
-    }
-
-    #[derive(Debug, Deserialize)]
-    struct WrapsFailingField {
-        #[allow(dead_code)]
-        inner: AlwaysFailsToDeserialize,
+    #[derive(Serialize, Deserialize)]
+    struct Message {
+        handles: Vec<OsHandle<OwnedFd>>,
     }
 
     #[test]
-    fn ordinary_values_are_postcard_compatible() {
-        let value = Compatibility {
-            some: Some(Newtype(42)),
-            none: None,
-            map: [("key".into(), Ordinary::Tuple(7, "value".into()))]
-                .into_iter()
-                .collect(),
-            variants: vec![
-                Ordinary::Unit,
-                Ordinary::Struct {
-                    values: vec![1, 2, 3],
-                },
-            ],
-        };
-        let mut frame = Frame(Vec::new());
-        let encoded = to_extend(&value, &mut frame, Vec::new()).unwrap();
-        assert_eq!(encoded, postcard::to_stdvec(&value).unwrap());
-        let mut handles = TestReceiver(Vec::new());
-        assert_eq!(
-            from_bytes::<Compatibility, _>(&encoded, &mut handles).unwrap(),
-            value
-        );
-    }
-
-    #[derive(Serialize)]
-    struct Sending {
-        handles: Option<Vec<OsHandle<OwnedFd>>>,
-    }
-    #[derive(Deserialize)]
-    struct Receiving {
-        handles: Option<Vec<OsHandle<OwnedFd>>>,
-    }
-
-    #[test]
-    fn nested_handles_round_trip_through_context() {
+    fn handles_round_trip_through_context() {
         let (fd, _) = pipe().unwrap();
-        let value = Sending {
-            handles: Some(vec![OsHandle::new(fd)]),
+        let value = Message {
+            handles: vec![OsHandle::new(fd)],
         };
-        let mut frame = Frame(Vec::new());
-        let encoded = to_extend(&value, &mut frame, Vec::new()).unwrap();
-        assert_eq!(frame.0.len(), 1);
-        let mut handles = TestReceiver(vec![Some(
-            value.handles.unwrap().pop().unwrap().into_inner(),
-        )]);
-        let decoded: Receiving = from_bytes(&encoded, &mut handles).unwrap();
-        assert_eq!(decoded.handles.unwrap().len(), 1);
+        let mut sender = Sender(EncodeHandles::for_test(1));
+        let bytes = encode_payload(&value, &mut sender).unwrap();
+        let sent = sender.0.finish().fds;
+        let decoded: Message =
+            decode_payload(&bytes, &mut Receiver(sent.into_iter().map(Some).collect())).unwrap();
+        assert_eq!(decoded.handles.len(), 1);
     }
 
     #[test]
-    fn trailing_bytes_are_rejected() {
-        let mut encoded = postcard::to_stdvec(&42u32).unwrap();
-        encoded.push(0);
-        let mut handles = TestReceiver(Vec::new());
-        assert!(
-            matches!(from_bytes::<u32, _>(&encoded, &mut handles), Err(Error::Message(message)) if message == "trailing bytes in payload")
-        );
-    }
-
-    #[test]
-    fn successful_serialization_steals_handle() {
+    fn serializing_one_handle_twice_is_rejected() {
         let (fd, _) = pipe().unwrap();
         let handle = OsHandle::new(fd);
-        let value = OneHandle { handle: &handle };
-        let mut handles = EncodeHandles::for_test(usize::MAX);
-        encode_payload(&value, &mut handles).unwrap();
-        let owned = handles.finish();
-        assert_eq!(owned.fds.len(), 1);
+        let value = (&handle, &handle);
+        let mut sender = Sender(EncodeHandles::for_test(2));
+        let error = encode_payload(&value, &mut sender).unwrap_err();
+        assert!(error.to_string().contains("same handle"));
+    }
+
+    #[test]
+    fn standalone_handle_serde_panics() {
+        let (fd, _) = pipe().unwrap();
+        let handle = OsHandle::new(fd);
         assert!(
-            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| { handle.into_inner() }))
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                postcard::to_allocvec(&handle)
+            }))
+            .is_err()
+        );
+        assert!(
+            std::panic::catch_unwind(|| postcard::from_bytes::<OsHandle<OwnedFd>>(&[0])).is_err()
+        );
+    }
+
+    #[test]
+    fn tls_scope_restores_after_unwind() {
+        let mut outer = Sender(EncodeHandles::for_test(0));
+        let outer: &mut dyn PutHandle = &mut outer;
+        let outer: &'static mut dyn PutHandle = unsafe { std::mem::transmute(outer) };
+        let _ = scope(&PUT, outer, || {
+            assert!(
+                std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    let mut inner = Sender(EncodeHandles::for_test(0));
+                    let inner: &mut dyn PutHandle = &mut inner;
+                    let inner: &'static mut dyn PutHandle = unsafe { std::mem::transmute(inner) };
+                    scope(&PUT, inner, || panic!("test unwind"));
+                }))
                 .is_err()
-        );
-    }
-
-    #[test]
-    fn failed_serialization_does_not_steal_handle() {
-        let (fd, _) = pipe().unwrap();
-        let handle = OsHandle::new(fd);
-        let mut handles = EncodeHandles::for_test(usize::MAX);
-        let error = encode_payload(&FailsAfterHandle(&handle), &mut handles).unwrap_err();
-        // Regression check for the postcard-discards-custom-errors plumbing:
-        // the message from the value's own `Serialize` impl must survive,
-        // not just a generic "something went wrong" from postcard.
-        assert!(error.to_string().contains("intentional failure"));
-        drop(handle.into_inner());
-    }
-
-    #[test]
-    fn custom_deserialize_error_message_is_preserved() {
-        // Regression check for the postcard-discards-custom-errors plumbing,
-        // deserialize side: the field's own `Deserialize` impl calls
-        // `Error::custom` deep inside the recursive `SeedWrap` boundary, and
-        // the message must still make it back to the caller.
-        let mut handles = TestReceiver(Vec::new());
-        let error = from_bytes::<WrapsFailingField, _>(&[0u8], &mut handles).unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("intentional deserialize failure")
-        );
-    }
-
-    #[test]
-    fn handle_limit_is_checked_before_stealing() {
-        let (fd, _) = pipe().unwrap();
-        let handle = OsHandle::new(fd);
-        let mut handles = EncodeHandles::for_test(0);
-        assert!(encode_payload(&OneHandle { handle: &handle }, &mut handles).is_err());
-        drop(handle.into_inner());
-    }
-
-    #[test]
-    fn repeated_handle_is_rejected_without_being_stolen() {
-        let (fd, _) = pipe().unwrap();
-        let handle = OsHandle::new(fd);
-        let value = RepeatedHandle {
-            first: &handle,
-            second: &handle,
-        };
-        let mut handles = EncodeHandles::for_test(usize::MAX);
-        assert!(encode_payload(&value, &mut handles).is_err());
-        drop(handle.into_inner());
-    }
-}
-
-#[cfg(all(test, windows))]
-mod windows_tests {
-    use std::io;
-    use std::os::windows::io::{FromRawHandle, IntoRawHandle, OwnedHandle};
-
-    use ::serde::{Deserialize, Serialize};
-
-    use super::*;
-    use crate::handle::OsHandle;
-
-    struct Frame(Option<usize>);
-
-    impl PutHandle<'_> for Frame {
-        fn put_handle(&mut self, handle: &dyn crate::handle::ErasedHandle) -> io::Result<usize> {
-            let raw = handle.raw_handle() as usize;
-            self.0 = Some(raw);
-            Ok(raw)
-        }
-    }
-
-    struct TestReceiver(Option<OwnedHandle>);
-
-    impl TakeHandle for TestReceiver {
-        fn take_handle(&mut self, value: usize) -> io::Result<OwnedHandle> {
-            use std::os::windows::io::AsRawHandle;
-            let handle = self.0.take().unwrap();
-            assert_eq!(handle.as_raw_handle() as usize, value);
-            Ok(handle)
-        }
-    }
-
-    #[derive(Serialize)]
-    struct Sending {
-        handle: OsHandle<OwnedHandle>,
-    }
-
-    #[derive(Deserialize)]
-    struct Receiving {
-        handle: OsHandle<OwnedHandle>,
-    }
-
-    #[test]
-    fn handle_round_trips_through_context() {
-        let file = std::fs::File::open(std::env::current_exe().unwrap()).unwrap();
-        let value = Sending {
-            handle: OsHandle::new(OwnedHandle::from(file)),
-        };
-        let mut frame = Frame(None);
-        let encoded = to_extend(&value, &mut frame, Vec::new()).unwrap();
-        let raw = value.handle.into_inner().into_raw_handle();
-        assert_eq!(frame.0, Some(raw as usize));
-        let mut receiver = TestReceiver(Some(unsafe { OwnedHandle::from_raw_handle(raw) }));
-        let received: Receiving = from_bytes(&encoded, &mut receiver).unwrap();
-        drop(received.handle);
+            );
+            PUT.with(|slot| assert!(slot.borrow().is_some()));
+        });
+        PUT.with(|slot| assert!(slot.borrow().is_none()));
     }
 }

--- a/dolang-rpc/src/server.rs
+++ b/dolang-rpc/src/server.rs
@@ -1,10 +1,10 @@
+#[cfg(windows)]
+use std::{any::TypeId, io, os::windows::io::OwnedHandle};
 use std::{
     collections::HashMap,
     marker::PhantomData,
     sync::{Arc, Mutex},
 };
-#[cfg(windows)]
-use std::{io, os::windows::io::OwnedHandle};
 
 use futures::{
     StreamExt,
@@ -16,15 +16,12 @@ use crate::{
     Error, Limits, Protocol,
     fragment::{self, Kind},
     serde::{decode_payload, encode_payload},
-    session::{self, InvalidOpaque, Opaque, OpaqueGuard, OpaqueResource, Session},
+    session::{self, Cite, Gift, InvalidOpaque, OpaqueGuard, OpaqueResource, Session},
     trailer::{RecvShared, SendShared, TrailerRecv, TrailerSend},
     transport::{self, EncodeHandles, Receiver, Sender},
 };
 #[cfg(windows)]
-use crate::{
-    handle::TakeHandle,
-    session::{Ref, Session},
-};
+use crate::{handle::TakeHandle, session::Inner as OpaqueInner};
 
 #[cfg(windows)]
 struct DecodeHandles<'a> {
@@ -47,9 +44,15 @@ impl TakeHandle for DecodeHandles<'_> {
         self.receiver.duplicate_peer_handle(value)
     }
 
-    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<Ref> {
+    fn take_gift(&mut self, owner: u8, id: u64) -> io::Result<OpaqueInner> {
         self.session
-            .take(owner, id)
+            .take_gift(owner, id)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
+    }
+
+    fn take_cite(&mut self, owner: u8, id: u64, marker: TypeId) -> io::Result<OpaqueInner> {
+        self.session
+            .take_cite(owner, id, marker)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
     }
 }
@@ -682,22 +685,45 @@ impl<P: Protocol> CallContext<P> {
 
     /// Registers a session-scoped resource and returns its serializable handle.
     ///
-    /// The registration lives as long as some [`Opaque`] naming it does — in
-    /// this process or in the peer's mirror of it. Dropping the last one
-    /// releases the resource, so a handle that is registered and then never
-    /// sent (because the call failed, or was cancelled before responding)
-    /// cleans itself up rather than stranding the entry.
-    pub fn register<T: OpaqueResource>(&self, value: T) -> Opaque<T::Marker> {
+    /// The registration lives as long as some handle naming it does — in this
+    /// process or in the peer's mirror of it. Dropping the last one releases
+    /// the resource, so a handle that is registered and then never sent
+    /// (because the call failed, or was cancelled before responding) cleans
+    /// itself up rather than stranding the entry.
+    ///
+    /// Registering yields a [`Gift`], which is what a wire position that grants
+    /// the peer a reference holds. To name an already-granted resource back to
+    /// the peer without granting another reference, send the same `Gift` again:
+    /// the peer merges the arrival into the handle it holds, and the extra
+    /// references collapse into one counted release.
+    ///
+    /// # Panics
+    ///
+    /// If a different concrete type has already been registered under
+    /// `T::Marker` on this session. A marker is the only type information the
+    /// wire carries, so it must name exactly one resource type.
+    pub fn register<T: OpaqueResource>(&self, value: T) -> Gift<T::Marker> {
         self.session.register(value)
     }
 
     /// Acquires a typed shared guard for a registered opaque resource.
     ///
-    /// Returns [`InvalidOpaque`] if the handle belongs to another session, was
-    /// unregistered, or does not refer to a resource with concrete type `T`.
+    /// Takes a [`Cite`], because only a citation names a resource this endpoint
+    /// owns; a peer that puts a gift in a citation position is rejected during
+    /// decode instead of arriving here.
+    ///
+    /// Returns [`InvalidOpaque`] if the resource was unregistered while the peer
+    /// still held a reference to it, which an ordinary race with
+    /// [`unregister`](Self::unregister) produces.
+    ///
+    /// # Panics
+    ///
+    /// If the handle was minted by a different session. Opaque ids are
+    /// session-scoped, so redeeming one elsewhere is a local logic error that
+    /// would otherwise resolve against an unrelated resource.
     pub fn acquire<T: OpaqueResource>(
         &self,
-        value: Opaque<T::Marker>,
+        value: Cite<T::Marker>,
     ) -> Result<OpaqueGuard<T>, InvalidOpaque> {
         self.session.acquire(value)
     }
@@ -708,9 +734,19 @@ impl<P: Protocol> CallContext<P> {
     /// The registration itself outlives this call until the peer has released
     /// its references, so a citation still in flight resolves to a revoked
     /// handle rather than an unknown one.
+    ///
+    /// # Panics
+    ///
+    /// If the handle was minted by a different session, as with
+    /// [`acquire`](Self::acquire).
+    /// Takes a [`Cite`], as [`acquire`](Self::acquire) does: a resource is
+    /// closed because the peer named it and asked, so what arrives here is the
+    /// citation that named it. An owner closing a resource of its own accord
+    /// has no need of this — dropping its last handle retires the registration
+    /// once the peer has released its references.
     pub fn unregister<T: OpaqueResource>(
         &self,
-        value: Opaque<T::Marker>,
+        value: Cite<T::Marker>,
     ) -> Result<Option<T>, InvalidOpaque> {
         self.session.unregister::<T>(value)
     }

--- a/dolang-rpc/src/server.rs
+++ b/dolang-rpc/src/server.rs
@@ -210,11 +210,10 @@ impl<P: Protocol> Server<P> {
                 }
                 fragment::Event::Trailer {
                     id,
-                    message,
                     shared,
                     len,
                     notify_discard,
-                } => (message, Some((id, shared, len, notify_discard))),
+                } => (None, Some((id, shared, len, notify_discard))),
             };
             if let Some(fragment::Message {
                 kind,

--- a/dolang-rpc/src/server.rs
+++ b/dolang-rpc/src/server.rs
@@ -3,6 +3,8 @@ use std::{
     marker::PhantomData,
     sync::{Arc, Mutex},
 };
+#[cfg(windows)]
+use std::{io, os::windows::io::OwnedHandle};
 
 use futures::{
     StreamExt,
@@ -14,28 +16,41 @@ use crate::{
     Error, Limits, Protocol,
     fragment::{self, Kind},
     serde::{decode_payload, encode_payload},
-    session::{self, InvalidOpaque, Opaque, OpaqueGuard, OpaqueResource},
+    session::{self, InvalidOpaque, Opaque, OpaqueGuard, OpaqueResource, Session},
+    trailer::{RecvShared, SendShared, TrailerRecv, TrailerSend},
     transport::{self, EncodeHandles, Receiver, Sender},
+};
+#[cfg(windows)]
+use crate::{
+    handle::TakeHandle,
+    session::{Ref, Session},
 };
 
 #[cfg(windows)]
 struct DecodeHandles<'a> {
     receiver: &'a transport::AnyReceiver,
+    session: &'a Arc<Session>,
     count: usize,
     max_handles: usize,
 }
 
 #[cfg(windows)]
-impl crate::handle::TakeHandle for DecodeHandles<'_> {
-    fn take_handle(&mut self, value: usize) -> std::io::Result<std::os::windows::io::OwnedHandle> {
+impl TakeHandle for DecodeHandles<'_> {
+    fn take_handle(&mut self, value: usize) -> io::Result<OwnedHandle> {
         if self.count == self.max_handles {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
                 "message contains too many handle attachments",
             ));
         }
         self.count += 1;
         self.receiver.duplicate_peer_handle(value)
+    }
+
+    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<Ref> {
+        self.session
+            .take(owner, id)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
     }
 }
 
@@ -54,6 +69,7 @@ pub struct Server<P: Protocol> {
     outgoing: mpsc::UnboundedSender<Message<P::Response>>,
     outgoing_rx: mpsc::UnboundedReceiver<Message<P::Response>>,
     inner: Arc<Mutex<Inner>>,
+    session: Arc<Session>,
     limits: Limits,
     marker: PhantomData<fn() -> P>,
 }
@@ -85,11 +101,28 @@ enum Message<R> {
     Ack {
         id: u64,
     },
+    /// Drops `count` of this endpoint's references to the peer's opaque `id`.
+    Release {
+        id: u64,
+        count: u32,
+    },
+}
+
+/// Emits `Release` frames for opaques whose last local handle dropped. The
+/// strong senders stay exactly what they were: `serve`'s own sender and each
+/// live `CallContext`.
+impl<R: Send + 'static> session::ReleaseSink for mpsc::WeakUnboundedSender<Message<R>> {
+    fn release(&self, id: u64, count: u32) {
+        // Called from `Drop`, so a departed channel is not an error: the
+        // writer is already gone and the peer's table dies with the session.
+        if let Some(outgoing) = self.upgrade() {
+            let _ = outgoing.send(Message::Release { id, count });
+        }
+    }
 }
 
 struct Inner {
     outstanding: HashMap<u64, Cancellation>,
-    objects: session::ObjectTable,
     shutdown: Option<oneshot::Sender<()>>,
     #[cfg(target_os = "macos")]
     fd_escrow: crate::escrow::FdEscrow,
@@ -112,14 +145,15 @@ impl<P: Protocol> Server<P> {
         limits: Limits,
     ) -> Self {
         let (outgoing, outgoing_rx) = mpsc::unbounded_channel();
+        let session = Session::new(Box::new(outgoing.downgrade()));
         Self {
             sender,
             receiver,
             outgoing,
             outgoing_rx,
+            session,
             inner: Arc::new(Mutex::new(Inner {
                 outstanding: HashMap::new(),
-                objects: session::ObjectTable::default(),
                 shutdown: None,
                 #[cfg(target_os = "macos")]
                 fd_escrow: Default::default(),
@@ -146,10 +180,17 @@ impl<P: Protocol> Server<P> {
             outgoing,
             outgoing_rx,
             inner,
+            session,
             limits,
             marker: _,
         } = self;
-        let mut writer = tokio::spawn(writer::<P>(sender, outgoing_rx, inner.clone(), limits));
+        let mut writer = tokio::spawn(writer::<P>(
+            sender,
+            outgoing_rx,
+            inner.clone(),
+            session.clone(),
+            limits,
+        ));
         let (shutdown, mut shutdown_requested) = oneshot::channel();
         inner.lock().unwrap().shutdown = Some(shutdown);
         let handler = Arc::new(handler);
@@ -214,6 +255,10 @@ impl<P: Protocol> Server<P> {
                     len,
                     notify_discard,
                 } => (None, Some((id, shared, len, notify_discard))),
+                fragment::Event::Release { id, count } => {
+                    session.release(id, count);
+                    (None, None)
+                }
             };
             if let Some(fragment::Message {
                 kind,
@@ -228,12 +273,19 @@ impl<P: Protocol> Server<P> {
                 match kind {
                     Kind::Request => {
                         #[cfg(unix)]
-                        let request = decode_payload(&payload, &mut { handles });
+                        let request = decode_payload(
+                            &payload,
+                            &mut session::SessionHandles {
+                                inner: handles,
+                                session: &session,
+                            },
+                        );
                         #[cfg(windows)]
                         let request = decode_payload(
                             &payload,
                             &mut DecodeHandles {
                                 receiver: &receiver,
+                                session: &session,
                                 count: 0,
                                 max_handles: limits.max_handles_per_message,
                             },
@@ -242,9 +294,10 @@ impl<P: Protocol> Server<P> {
                             Ok(request) => request,
                             Err(error) => break (Err(error), false, false),
                         };
-                        let trailer = trailer.map(crate::trailer::TrailerRecv::new);
+                        let trailer = trailer.map(TrailerRecv::new);
                         let handler = handler.clone();
                         let task_inner = inner.clone();
+                        let task_session = session.clone();
                         let task_outgoing = outgoing.clone();
                         let (abort, registration) = AbortHandle::new_pair();
                         tasks.push(Abortable::new(
@@ -252,6 +305,7 @@ impl<P: Protocol> Server<P> {
                                 let context = CallContext {
                                     id,
                                     inner: task_inner.clone(),
+                                    session: task_session,
                                     request_trailer: trailer,
                                     outgoing: task_outgoing,
                                     responded: false,
@@ -324,10 +378,10 @@ impl<P: Protocol> Server<P> {
                 let frame = receiver.recv();
                 // SAFETY: the lease retains the receiver borrow and clears
                 // the erased token before it ends.
-                let lease = unsafe { crate::trailer::RecvShared::grant(&shared, frame, len) };
+                let lease = unsafe { RecvShared::grant(&shared, frame, len) };
                 let result = loop {
                     tokio::select! {
-                        result = crate::trailer::RecvShared::wait_fragment(&shared) => break result,
+                        result = RecvShared::wait_fragment(&shared) => break result,
                         Some(_) = tasks.next(), if !tasks.is_empty() => continue,
                         _ = &mut shutdown_requested => break 'main (Ok(()), false, true),
                         result = &mut writer => {
@@ -389,6 +443,7 @@ async fn writer<P: Protocol>(
     mut sender: transport::AnySender,
     mut outgoing: mpsc::UnboundedReceiver<Message<P::Response>>,
     inner: Arc<Mutex<Inner>>,
+    session: Arc<Session>,
     limits: Limits,
 ) -> Result<(), Error> {
     let mut scheduler = fragment::Scheduler::new(&limits);
@@ -407,7 +462,7 @@ async fn writer<P: Protocol>(
                     closed = true;
                     continue;
                 };
-                admit::<P>(&mut sender, &mut scheduler, &inner, &limits, message).await?;
+                admit::<P>(&mut sender, &mut scheduler, &inner, &session, &limits, message).await?;
             }
             // Not raced against anything — see the matching comment in
             // client.rs's writer loop. A dropped send future could leave a
@@ -436,6 +491,7 @@ async fn admit<P: Protocol>(
     sender: &mut transport::AnySender,
     scheduler: &mut fragment::Scheduler,
     inner: &Arc<Mutex<Inner>>,
+    session: &Arc<Session>,
     limits: &Limits,
     message: Message<P::Response>,
 ) -> Result<(), Error> {
@@ -451,8 +507,23 @@ async fn admit<P: Protocol>(
             };
             #[cfg(windows)]
             let max_handles = limits.max_handles_per_message;
-            let mut put_handles = EncodeHandles::new(sender, max_handles);
-            let payload = encode_payload(&value, &mut put_handles)?;
+            let mut ledger = session::Ledger::default();
+            let mut put_handles = session::SessionFrame {
+                inner: EncodeHandles::new(sender, max_handles),
+                session,
+                ledger: &mut ledger,
+            };
+            let payload = match encode_payload(&value, &mut put_handles) {
+                Ok(payload) => payload,
+                Err(error) => {
+                    drop(put_handles);
+                    // Nothing reached the wire, so undo the gift increments
+                    // rather than letting the ledger's drop commit them.
+                    ledger.rescind();
+                    return Err(error);
+                }
+            };
+            let put_handles = put_handles.inner;
             #[cfg(unix)]
             let handles = put_handles.finish();
             #[cfg(target_os = "macos")]
@@ -463,7 +534,7 @@ async fn admit<P: Protocol>(
             let (handles, escrow) = put_handles.finish();
             #[cfg(windows)]
             drop(escrow);
-            scheduler.admit_message(Kind::Response, id, payload, handles, trailer);
+            scheduler.admit_message(Kind::Response, id, payload, handles, trailer, ledger);
         }
         Message::Error { id } => scheduler.admit_empty(Kind::Error, id),
         Message::Cancel { id } => match scheduler.try_cancel_active(id) {
@@ -481,6 +552,7 @@ async fn admit<P: Protocol>(
         Message::DiscardTrailer { id } => scheduler.admit_empty(Kind::Discard, id),
         Message::PeerDiscarded { id } => scheduler.discard_active_trailer(id),
         Message::Ack { id } => scheduler.admit_empty(Kind::Ack, id),
+        Message::Release { id, count } => scheduler.admit_release(id, count),
     }
     Ok(())
 }
@@ -491,7 +563,8 @@ async fn admit<P: Protocol>(
 pub struct CallContext<P: Protocol> {
     id: u64,
     inner: Arc<Mutex<Inner>>,
-    request_trailer: Option<crate::trailer::TrailerRecv>,
+    session: Arc<Session>,
+    request_trailer: Option<TrailerRecv>,
     outgoing: mpsc::UnboundedSender<Message<P::Response>>,
     responded: bool,
     shutdown_on_respond: bool,
@@ -506,7 +579,7 @@ impl<P: Protocol> CallContext<P> {
     /// Dropping it or calling [`TrailerRecv::discard`](crate::trailer::TrailerRecv::discard)
     /// stops local consumption; the peer is notified only if it continues to
     /// send trailer fragments.
-    pub fn request_trailer(&mut self) -> Option<&mut crate::trailer::TrailerRecv> {
+    pub fn request_trailer(&mut self) -> Option<&mut TrailerRecv> {
         self.request_trailer.as_mut()
     }
 
@@ -531,12 +604,9 @@ impl<P: Protocol> CallContext<P> {
     /// asynchronously shut down the returned writer, to commit the trailer.
     /// Dropping it without finishing aborts the trailer. Any unread request
     /// trailer is discarded.
-    pub fn respond_with_trailer(
-        mut self,
-        response: P::Response,
-    ) -> crate::trailer::TrailerSend<()> {
+    pub fn respond_with_trailer(mut self, response: P::Response) -> TrailerSend<()> {
         drop(self.request_trailer.take());
-        let shared = crate::trailer::SendShared::new(Kind::Response, self.id, &self.limits);
+        let shared = SendShared::new(Kind::Response, self.id, &self.limits);
         self.responded = true;
         self.inner.lock().unwrap().outstanding.remove(&self.id);
         let _ = self.outgoing.send(Message::Response {
@@ -545,7 +615,7 @@ impl<P: Protocol> CallContext<P> {
             trailer: fragment::Trailer::Stream(shared.clone()),
         });
         self.finish_shutdown();
-        crate::trailer::TrailerSend::new(shared, ())
+        TrailerSend::new(shared, ())
     }
 
     /// Requests graceful shutdown after this handler sends its response.
@@ -612,11 +682,13 @@ impl<P: Protocol> CallContext<P> {
 
     /// Registers a session-scoped resource and returns its serializable handle.
     ///
-    /// The caller owns the resource's lifetime and must eventually unregister
-    /// it. Cloning, sending, or dropping the returned [`Opaque`] does not
-    /// affect the registration.
+    /// The registration lives as long as some [`Opaque`] naming it does — in
+    /// this process or in the peer's mirror of it. Dropping the last one
+    /// releases the resource, so a handle that is registered and then never
+    /// sent (because the call failed, or was cancelled before responding)
+    /// cleans itself up rather than stranding the entry.
     pub fn register<T: OpaqueResource>(&self, value: T) -> Opaque<T::Marker> {
-        self.inner.lock().unwrap().objects.register(value)
+        self.session.register(value)
     }
 
     /// Acquires a typed shared guard for a registered opaque resource.
@@ -627,18 +699,20 @@ impl<P: Protocol> CallContext<P> {
         &self,
         value: Opaque<T::Marker>,
     ) -> Result<OpaqueGuard<T>, InvalidOpaque> {
-        self.inner.lock().unwrap().objects.acquire(value)
+        self.session.acquire(value)
     }
 
-    /// Removes a typed opaque resource from this session.
+    /// Empties a typed opaque resource, returning it when no acquired guards
+    /// still share its ownership.
     ///
-    /// Returns the resource when no acquired guards still share its ownership,
-    /// or `None` after removing it when another call retains a guard.
+    /// The registration itself outlives this call until the peer has released
+    /// its references, so a citation still in flight resolves to a revoked
+    /// handle rather than an unknown one.
     pub fn unregister<T: OpaqueResource>(
         &self,
         value: Opaque<T::Marker>,
     ) -> Result<Option<T>, InvalidOpaque> {
-        self.inner.lock().unwrap().objects.unregister::<T>(value)
+        self.session.unregister::<T>(value)
     }
 }
 

--- a/dolang-rpc/src/session.rs
+++ b/dolang-rpc/src/session.rs
@@ -1,8 +1,10 @@
 //! Session-scoped opaque resources.
 //!
-//! [`Opaque`] is a reference to a resource retained by one endpoint of a
-//! session. It can be redeemed only through that endpoint, and only while the
-//! resource remains registered.
+//! [`Gift`] and [`Cite`] are references to a resource retained by one endpoint
+//! of a session. Either can be redeemed only through that endpoint, and only
+//! while the resource remains registered. They are the same handle in different
+//! wire positions — see "Direction is load-bearing" below, which is the
+//! distinction the two types exist to make static.
 //!
 //! # Reference counting
 //!
@@ -13,8 +15,8 @@
 //!   the owner has handed the peer. The owner increments it when it serializes
 //!   a gift; the peer mirrors it when it deserializes one. Only a
 //!   [`Kind::Release`](crate::fragment::Kind::Release) moves it down.
-//! * The **local handle count** is the `Arc` inside [`Opaque`] itself: how
-//!   many live values in this process name the resource. Cloning an `Opaque`
+//! * The **local handle count** is the `Arc` inside the handle itself: how
+//!   many live values in this process name the resource. Cloning a handle
 //!   grants the peer nothing, so it must not touch the protocol count — a
 //!   shared counter would inflate the eventual release by every local clone
 //!   and make the owner decrement more than it ever granted.
@@ -35,16 +37,25 @@
 //!   is the hot path. It must have no protocol effect whatsoever. Citations
 //!   are safe unconditionally: the caller necessarily holds a reference for
 //!   the duration of the call it is citing the opaque in.
+//!
+//! Which of the two a wire position means is fixed by the protocol, never by
+//! the value that lands in it, so it is spelled in the field's type: [`Gift`]
+//! or [`Cite`]. The receiver then rejects the wrong one during decode, where
+//! the expectation is still statically known, rather than discovering at
+//! redemption that the peer sent the other kind.
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 #[cfg(unix)]
 use std::os::fd::OwnedFd;
 use std::{
     any::{Any, TypeId},
-    collections::HashMap,
+    collections::{HashMap, hash_map::Entry},
     fmt, io,
     marker::PhantomData,
-    sync::{Arc, Mutex, Weak},
+    sync::{
+        Arc, Mutex, Weak,
+        atomic::{AtomicU64, Ordering},
+    },
 };
 
 #[cfg(unix)]
@@ -71,11 +82,15 @@ const WIRE_CITATION: u8 = 1;
 
 /// A value that can be registered in a session's opaque-object table.
 ///
-/// `Marker` is the public protocol-level type carried by [`Opaque`]. The
-/// concrete resource type may remain private. A marker does not by itself
-/// authorize a downcast: [`Session::acquire`] also verifies the concrete type.
+/// `Marker` is the public protocol-level type carried by [`Gift`] and [`Cite`];
+/// it is nothing but a name, so that the concrete resource type may remain
+/// private.
+/// The mapping from marker to resource must be injective, and
+/// `Session::register` panics if an application ever registers two concrete
+/// types under one marker — otherwise a marker would not identify a type and
+/// the wire could not be typechecked at all.
 pub trait OpaqueResource: Send + Sync + 'static {
-    type Marker: ?Sized + 'static;
+    type Marker: 'static;
 }
 
 /// Emits release frames for opaques whose last local handle has dropped.
@@ -94,11 +109,14 @@ pub(crate) trait ReleaseSink: Send + Sync + 'static {
 ///
 /// The `Arc` around it is the local handle count. The resource itself lives in
 /// the session table, never in here, so that [`Session::unregister`] can empty
-/// the slot and have every outstanding `Opaque` observe the revocation. That
-/// is the whole reason [`Session::acquire`] is fallible: resolving an opaque is
+/// the slot and have every outstanding handle observe the revocation. That
+/// is the whole reason `Session::acquire` is fallible: resolving an opaque is
 /// `open()` on a descriptor number, not a pointer dereference.
 pub(crate) struct LocalRef {
     id: u64,
+    /// Which session minted this handle. An id means nothing outside the
+    /// session that issued it, so every redemption checks it.
+    serial: u64,
     session: Weak<Session>,
 }
 
@@ -110,15 +128,19 @@ pub(crate) struct LocalRef {
 /// it rather than splitting it.
 pub(crate) struct RemoteRef {
     id: u64,
+    /// See [`LocalRef::serial`].
+    serial: u64,
     session: Weak<Session>,
 }
 
-pub(crate) enum Ref {
+/// The handle behind a [`Gift`] or a [`Cite`], which differ only in the wire
+/// position they are legal in — this carries everything either of them does.
+pub(crate) enum Inner {
     Local(Arc<LocalRef>),
     Remote(Arc<RemoteRef>),
 }
 
-impl Clone for Ref {
+impl Clone for Inner {
     fn clone(&self) -> Self {
         // Purely a local handle count bump; the protocol count is untouched.
         match self {
@@ -128,7 +150,7 @@ impl Clone for Ref {
     }
 }
 
-impl Ref {
+impl Inner {
     fn id(&self) -> u64 {
         match self {
             Self::Local(local) => local.id,
@@ -200,56 +222,149 @@ impl Drop for RemoteRef {
     }
 }
 
-/// A session-scoped reference to a registered resource.
+/// Panic message shared by the two places that catch the same mistake.
+const CITE_OWNED: &str = "cannot cite a resource this endpoint owns; \
+                          gift it again to name it to the peer";
+
+/// An opaque handle in a wire position that *grants* a reference: the sender
+/// owns the resource, and the receiver comes away holding one reference more
+/// than it did.
+///
+/// This is both what `Session::register` produces and what the receiving
+/// endpoint decodes a gift into, and those are not the same thing: the owner's
+/// `Gift` names a resource it owns, while the peer's names a mirror of one it
+/// does not. The type marks the wire position, not the holder's relationship
+/// to the resource — which is why naming one back to its owner has to go
+/// through [`Gift::cite`].
 ///
 /// This is a reference, not the resource itself. It becomes invalid when its
 /// owner unregisters the resource or the session ends. Dropping the last
-/// `Opaque` naming a resource the peer owns releases the endpoint's references
+/// `Gift` naming a resource the peer owns releases the endpoint's references
 /// to it automatically — no explicit protocol close is required to avoid
 /// leaking it.
-pub struct Opaque<M: ?Sized> {
-    pub(crate) inner: Ref,
+///
+/// Gifting one resource repeatedly is well-defined and is how an owner names
+/// an already-granted resource back to the peer — for a completion report, say.
+/// The peer's `receive` merges the arrival into the handle
+/// it already holds, so the reference it gets back compares equal to the one it
+/// has, and the accumulated total collapses into a single counted release.
+pub struct Gift<M> {
+    pub(crate) inner: Inner,
     marker: PhantomData<fn() -> M>,
 }
 
-impl<M: ?Sized> Clone for Opaque<M> {
-    fn clone(&self) -> Self {
+/// An opaque handle in a wire position that *names* a reference the receiver
+/// has already granted: the receiver owns the resource and no reference
+/// changes hands.
+///
+/// Produced only by [`Gift::cite`], and redeemed with `Session::acquire` by
+/// the endpoint that owns the resource. A citation cannot legitimately race the
+/// release of the reference it names — see `Session::cite` — so one the table
+/// cannot account for fails the decode rather than failing the call.
+pub struct Cite<M> {
+    pub(crate) inner: Inner,
+    marker: PhantomData<fn() -> M>,
+}
+
+impl<M> Cite<M> {
+    pub(crate) fn new(inner: Inner) -> Self {
         Self {
+            inner,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<M> Gift<M> {
+    pub(crate) fn new(inner: Inner) -> Self {
+        Self {
+            inner,
+            marker: PhantomData,
+        }
+    }
+
+    /// Names this resource back to the endpoint that owns it.
+    ///
+    /// # Panics
+    ///
+    /// If this endpoint is itself the owner. A citation says "the reference you
+    /// granted me", which is meaningless pointed at one's own table; gift the
+    /// resource again instead.
+    pub fn cite(&self) -> Cite<M> {
+        assert!(matches!(self.inner, Inner::Remote(_)), "{CITE_OWNED}");
+        Cite {
             inner: self.inner.clone(),
             marker: PhantomData,
         }
     }
 }
 
-impl<M: ?Sized> PartialEq for Opaque<M> {
-    fn eq(&self, other: &Self) -> bool {
-        self.inner.owner() == other.inner.owner() && self.inner.id() == other.inner.id()
-    }
+/// The two handle types differ only in the wire position they are legal in, so
+/// everything that does not touch the wire is identical between them.
+macro_rules! opaque_handle {
+    ($name:ident) => {
+        impl<M> Clone for $name<M> {
+            fn clone(&self) -> Self {
+                Self {
+                    inner: self.inner.clone(),
+                    marker: PhantomData,
+                }
+            }
+        }
+
+        impl<M> PartialEq for $name<M> {
+            fn eq(&self, other: &Self) -> bool {
+                self.inner.owner() == other.inner.owner() && self.inner.id() == other.inner.id()
+            }
+        }
+
+        impl<M> Eq for $name<M> {}
+
+        impl<M> fmt::Debug for $name<M> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.debug_struct(stringify!($name))
+                    .field("owner", &self.inner.owner())
+                    .field("id", &self.inner.id())
+                    .finish_non_exhaustive()
+            }
+        }
+    };
 }
 
-impl<M: ?Sized> Eq for Opaque<M> {}
+opaque_handle!(Gift);
+opaque_handle!(Cite);
 
-impl<M: ?Sized> fmt::Debug for Opaque<M> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_struct("Opaque")
-            .field("owner", &self.inner.owner())
-            .field("id", &self.inner.id())
-            .finish_non_exhaustive()
-    }
-}
-
-impl<M: ?Sized> Serialize for Opaque<M> {
+impl<M> Serialize for Gift<M> {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        assert!(
+            matches!(self.inner, Inner::Local(_)),
+            "cannot gift a resource this endpoint does not own; \
+             use `Gift::cite` to name it back to its owner"
+        );
         crate::serde::serialize_opaque(&self.inner, serializer)
     }
 }
 
-impl<'de, M: ?Sized> Deserialize<'de> for Opaque<M> {
+impl<'de, M> Deserialize<'de> for Gift<M> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        crate::serde::deserialize_opaque(deserializer).map(|inner| Opaque {
-            inner,
-            marker: PhantomData,
-        })
+        // No marker check: the peer's table is the authority on the type of a
+        // resource the peer owns, and this side has nothing to check it against.
+        crate::serde::deserialize_gift(deserializer).map(Gift::new)
+    }
+}
+
+impl<M> Serialize for Cite<M> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        assert!(matches!(self.inner, Inner::Remote(_)), "{CITE_OWNED}");
+        crate::serde::serialize_opaque(&self.inner, serializer)
+    }
+}
+
+impl<'de, M: 'static> Deserialize<'de> for Cite<M> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        // The marker travels with the request so the session can check an
+        // arriving citation against the type it registered the id under.
+        crate::serde::deserialize_cite(deserializer, TypeId::of::<M>()).map(Cite::new)
     }
 }
 
@@ -272,6 +387,9 @@ pub struct InvalidOpaque;
 
 struct LocalEntry {
     ty: TypeId,
+    /// The marker the resource was registered under, checked against the one
+    /// the wire position declares when a citation arrives.
+    marker: TypeId,
     /// `None` once [`Session::unregister`] has emptied the handle. The entry
     /// itself survives so that a citation still in flight from the peer is
     /// distinguishable from an unknown id, and so the id cannot be reused
@@ -316,19 +434,78 @@ struct Tables {
 /// that only ever receives opaques still needs `remote`, because dropping
 /// those references is what frees the peer's resources.
 pub(crate) struct Session {
+    /// Distinguishes this session from every other one in the process, so that
+    /// an [`Opaque`] redeemed against the wrong endpoint is caught rather than
+    /// silently resolving to whatever that endpoint happens to hold under the
+    /// same id.
+    serial: u64,
     tables: Mutex<Tables>,
+    /// Marker type -> the concrete resource type registered under it, with its
+    /// name for diagnostics. Kept out of `tables` so that the conflict panic
+    /// cannot poison the table lock.
+    markers: Mutex<HashMap<TypeId, (TypeId, &'static str)>>,
     sink: Box<dyn ReleaseSink>,
 }
 
 impl Session {
     pub(crate) fn new(sink: Box<dyn ReleaseSink>) -> Arc<Self> {
+        static NEXT_SERIAL: AtomicU64 = AtomicU64::new(0);
         Arc::new(Self {
+            serial: NEXT_SERIAL.fetch_add(1, Ordering::Relaxed),
             tables: Mutex::new(Tables::default()),
+            markers: Mutex::new(HashMap::new()),
             sink,
         })
     }
 
-    pub(crate) fn register<T: OpaqueResource>(self: &Arc<Self>, value: T) -> Opaque<T::Marker> {
+    /// Rejects an [`Opaque`] minted by a different session.
+    ///
+    /// A panic rather than an error: ids are session-scoped, so a foreign one
+    /// is a pure local logic error that no peer and no race can produce, and
+    /// the alternative is resolving it against an unrelated resource that
+    /// happens to share the id.
+    fn check_serial(&self, serial: u64) {
+        assert_eq!(
+            serial, self.serial,
+            "opaque reference redeemed against a different session"
+        );
+    }
+
+    /// Records the marker under which `T` is registered, panicking if the
+    /// application has already used that marker for a different resource type.
+    ///
+    /// The wire carries only `(owner, id)`; a marker is what a protocol
+    /// declares a position to hold. Two resource types behind one marker would
+    /// leave [`take`](Self::take) unable to tell a well-typed citation from a
+    /// peer naming the wrong object, so the ambiguity is refused outright.
+    fn record_marker<T: OpaqueResource>(&self) {
+        let marker = TypeId::of::<T::Marker>();
+        let previous = {
+            let mut markers = self.markers.lock().unwrap();
+            match markers.entry(marker) {
+                Entry::Occupied(entry) if entry.get().0 != TypeId::of::<T>() => Some(entry.get().1),
+                Entry::Occupied(_) => None,
+                Entry::Vacant(entry) => {
+                    entry.insert((TypeId::of::<T>(), std::any::type_name::<T>()));
+                    None
+                }
+            }
+        };
+        // Outside the lock: a panic here must not poison the map for the rest
+        // of the session.
+        if let Some(previous) = previous {
+            panic!(
+                "opaque marker `{}` is already registered for resource type `{}`; \
+                 it cannot also name `{}`",
+                std::any::type_name::<T::Marker>(),
+                previous,
+                std::any::type_name::<T>(),
+            );
+        }
+    }
+
+    pub(crate) fn register<T: OpaqueResource>(self: &Arc<Self>, value: T) -> Gift<T::Marker> {
+        self.record_marker::<T>();
         let mut tables = self.tables.lock().unwrap();
         let id = tables.next;
         tables.next = tables
@@ -337,35 +514,47 @@ impl Session {
             .expect("opaque identifiers exhausted");
         let handle = Arc::new(LocalRef {
             id,
+            serial: self.serial,
             session: Arc::downgrade(self),
         });
         tables.local.insert(
             id,
             LocalEntry {
                 ty: TypeId::of::<T>(),
+                marker: TypeId::of::<T::Marker>(),
                 resource: Some(Arc::new(value)),
                 granted: 0,
                 handle: Arc::downgrade(&handle),
             },
         );
-        Opaque {
-            inner: Ref::Local(handle),
-            marker: PhantomData,
-        }
+        Gift::new(Inner::Local(handle))
     }
 
     pub(crate) fn acquire<T: OpaqueResource>(
         &self,
-        value: Opaque<T::Marker>,
+        value: Cite<T::Marker>,
     ) -> Result<OpaqueGuard<T>, InvalidOpaque> {
-        let Ref::Local(local) = &value.inner else {
+        // Unreachable for a citation that arrived over the wire: a `Cite` is
+        // decoded only from `WIRE_CITATION`, which resolves against this
+        // endpoint's own table and so is always local. Only a locally minted
+        // one can be remote, and `Gift::cite` refuses to mint that.
+        let Inner::Local(local) = &value.inner else {
             return Err(InvalidOpaque);
         };
+        self.check_serial(local.serial);
         let tables = self.tables.lock().unwrap();
+        // Unreachable while this handle is alive: the entry is retired only
+        // once no handle points at it, and `cite` refuses an id with no entry
+        // rather than minting one.
         let entry = tables.local.get(&local.id).ok_or(InvalidOpaque)?;
+        // Likewise unreachable: `cite` rejects a citation whose marker does not
+        // match the entry, and `record_marker` makes the marker determine the
+        // type. Kept as an integer compare guarding the downcast.
         if entry.ty != TypeId::of::<T>() {
             return Err(InvalidOpaque);
         }
+        // The live case: `unregister` emptied the slot while the peer still
+        // held a reference, so a citation already in flight lands here.
         let resource = entry.resource.as_ref().ok_or(InvalidOpaque)?;
         Ok(OpaqueGuard(
             resource
@@ -387,11 +576,13 @@ impl Session {
     /// no-op; on a pipe's send end that is a missing EOF and a hung reader.
     pub(crate) fn unregister<T: OpaqueResource>(
         &self,
-        value: Opaque<T::Marker>,
+        value: Cite<T::Marker>,
     ) -> Result<Option<T>, InvalidOpaque> {
-        let Ref::Local(local) = &value.inner else {
+        // Unreachable for a decoded citation, as in `acquire`.
+        let Inner::Local(local) = &value.inner else {
             return Err(InvalidOpaque);
         };
+        self.check_serial(local.serial);
         let mut tables = self.tables.lock().unwrap();
         let entry = tables.local.get_mut(&local.id).ok_or(InvalidOpaque)?;
         if entry.ty != TypeId::of::<T>() {
@@ -427,7 +618,7 @@ impl Session {
 
     /// Mirrors an arriving gift for `id`, merging into the handle this
     /// endpoint already holds when there is one.
-    fn receive(self: &Arc<Self>, id: u64) -> Ref {
+    fn receive(self: &Arc<Self>, id: u64) -> Inner {
         let mut tables = self.tables.lock().unwrap();
         let session = Arc::downgrade(self);
         let entry = tables.remote.entry(id).or_insert_with(|| RemoteEntry {
@@ -440,48 +631,87 @@ impl Session {
         // including its own references and the one arriving now — to the fresh
         // handle installed here.
         if let Some(handle) = entry.handle.upgrade() {
-            return Ref::Remote(handle);
+            return Inner::Remote(handle);
         }
-        let handle = Arc::new(RemoteRef { id, session });
+        let handle = Arc::new(RemoteRef {
+            id,
+            serial: self.serial,
+            session,
+        });
         entry.handle = Arc::downgrade(&handle);
-        Ref::Remote(handle)
+        Inner::Remote(handle)
     }
 
     /// Resolves an arriving citation back to a handle on the resource this
     /// endpoint owns.
     ///
-    /// An unknown id yields a handle with no table entry rather than an error:
-    /// the peer may legitimately be citing something we have just retired, and
-    /// failing here would tear down the whole session over a benign race.
-    /// [`acquire`](Self::acquire) reports it as [`InvalidOpaque`] instead.
-    fn cite(self: &Arc<Self>, id: u64) -> Ref {
+    /// Both failures mean the peer has named something it cannot name, and
+    /// both are refused rather than papered over.
+    ///
+    /// An entry registered under a marker other than the one the wire position
+    /// declares is the only thing standing between a peer and a guard on the
+    /// wrong resource.
+    ///
+    /// An unknown id means the counts have diverged. It cannot arise from a
+    /// race: `granted` rises when a gift is *serialized* and falls only on a
+    /// release, the entry is retired only once it reaches zero with no live
+    /// handle, and [`Escrowed::Citation`] holds the peer's reference until the
+    /// citing payload is fully written — so the release for a cited id is
+    /// always generated after the last fragment of the message citing it. A
+    /// peer citing a retired id is therefore counting differently than we are,
+    /// and nothing it says about this table can be trusted afterwards.
+    fn cite(self: &Arc<Self>, id: u64, marker: TypeId) -> Result<Inner, InvalidOpaque> {
         let mut tables = self.tables.lock().unwrap();
-        if let Some(entry) = tables.local.get_mut(&id) {
-            if let Some(handle) = entry.handle.upgrade() {
-                return Ref::Local(handle);
-            }
-            let handle = Arc::new(LocalRef {
-                id,
-                session: Arc::downgrade(self),
-            });
-            entry.handle = Arc::downgrade(&handle);
-            return Ref::Local(handle);
+        let entry = tables.local.get_mut(&id).ok_or(InvalidOpaque)?;
+        if entry.marker != marker {
+            return Err(InvalidOpaque);
         }
-        Ref::Local(Arc::new(LocalRef {
+        if let Some(handle) = entry.handle.upgrade() {
+            return Ok(Inner::Local(handle));
+        }
+        // The owner has dropped its last handle but the peer still holds
+        // references, so the entry outlived it. Install a fresh handle.
+        let handle = Arc::new(LocalRef {
             id,
+            serial: self.serial,
             session: Arc::downgrade(self),
-        }))
+        });
+        entry.handle = Arc::downgrade(&handle);
+        Ok(Inner::Local(handle))
     }
 
-    /// Resolves an arriving `(owner, id)` pair against this endpoint.
-    pub(crate) fn take(self: &Arc<Self>, owner: u8, id: u64) -> Result<Ref, InvalidOpaque> {
-        match owner {
-            // The sender owns it: a gift, which we mirror.
-            WIRE_GIFT => Ok(self.receive(id)),
-            // We own it: a citation coming home.
-            WIRE_CITATION => Ok(self.cite(id)),
-            _ => Err(InvalidOpaque),
+    /// Resolves an arriving `(owner, id)` pair for a wire position declared to
+    /// hold a [`Gift`]: the sender owns the resource and this side mirrors it.
+    ///
+    /// Nothing is typechecked, because there is nothing here to check against —
+    /// the peer's table is the authority on the type of the peer's own
+    /// resource. The owner bit is, though: a citation in a gift position names
+    /// something this endpoint owns, which is not a reference the peer can
+    /// grant.
+    pub(crate) fn take_gift(self: &Arc<Self>, owner: u8, id: u64) -> Result<Inner, InvalidOpaque> {
+        if owner != WIRE_GIFT {
+            return Err(InvalidOpaque);
         }
+        Ok(self.receive(id))
+    }
+
+    /// Resolves an arriving `(owner, id)` pair for a wire position declared to
+    /// hold a [`Cite`] of `marker`: a citation coming home, typechecked as such.
+    ///
+    /// Both a wrong owner bit and a citation the table cannot account for fail
+    /// the decode, which ends the connection — see [`Session::cite`]. Neither
+    /// can arise from a race, so tolerating either would mean accepting that
+    /// this endpoint and its peer disagree about the table.
+    pub(crate) fn take_cite(
+        self: &Arc<Self>,
+        owner: u8,
+        id: u64,
+        marker: TypeId,
+    ) -> Result<Inner, InvalidOpaque> {
+        if owner != WIRE_CITATION {
+            return Err(InvalidOpaque);
+        }
+        self.cite(id, marker)
     }
 }
 
@@ -511,13 +741,18 @@ pub(crate) struct Ledger {
 impl Ledger {
     /// Records an opaque encountered during serialization, returning its wire
     /// `(owner, id)`.
-    pub(crate) fn put(&mut self, value: &Ref, session: &Arc<Session>) -> (u8, u64) {
+    pub(crate) fn put(&mut self, value: &Inner, session: &Arc<Session>) -> (u8, u64) {
         match value {
-            Ref::Local(local) => {
+            Inner::Local(local) => {
+                // Writing a foreign id onto this session's wire would grant the
+                // peer a reference to whatever *this* session holds under that
+                // id, so the check matters more here than at redemption.
+                session.check_serial(local.serial);
                 self.items.push(session.gift(local));
                 (WIRE_GIFT, local.id)
             }
-            Ref::Remote(remote) => {
+            Inner::Remote(remote) => {
+                session.check_serial(remote.serial);
                 self.items.push(Escrowed::Citation(remote.clone()));
                 (WIRE_CITATION, remote.id)
             }
@@ -574,7 +809,7 @@ impl PutHandle for SessionFrame<'_> {
         self.inner.put_handle(handle)
     }
 
-    fn put_opaque(&mut self, opaque: &Ref) -> io::Result<(u8, u64)> {
+    fn put_opaque(&mut self, opaque: &Inner) -> io::Result<(u8, u64)> {
         Ok(self.ledger.put(opaque, self.session))
     }
 }
@@ -595,9 +830,15 @@ impl TakeHandle for SessionHandles<'_> {
     fn finish(&mut self) -> io::Result<()> {
         self.inner.finish()
     }
-    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<Ref> {
+    fn take_gift(&mut self, owner: u8, id: u64) -> io::Result<Inner> {
         self.session
-            .take(owner, id)
+            .take_gift(owner, id)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
+    }
+
+    fn take_cite(&mut self, owner: u8, id: u64, marker: TypeId) -> io::Result<Inner> {
+        self.session
+            .take_cite(owner, id, marker)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
     }
 }
@@ -623,6 +864,7 @@ mod tests {
 
     struct Marker;
     struct OtherMarker;
+    struct DropMarker;
     struct Value(u32);
     struct OtherValue;
     struct DropValue(Arc<AtomicBool>);
@@ -633,7 +875,7 @@ mod tests {
         type Marker = OtherMarker;
     }
     impl OpaqueResource for DropValue {
-        type Marker = Marker;
+        type Marker = DropMarker;
     }
     impl Drop for DropValue {
         fn drop(&mut self) {
@@ -641,26 +883,89 @@ mod tests {
         }
     }
 
+    /// The citation an owner gets back when the peer names one of its
+    /// resources to it, which is the only way a `Cite` legitimately reaches
+    /// `acquire`.
+    fn cited<M: 'static>(session: &Arc<Session>, gift: &Gift<M>) -> Cite<M> {
+        Cite::new(
+            session
+                .take_cite(WIRE_CITATION, gift.inner.id(), TypeId::of::<M>())
+                .unwrap(),
+        )
+    }
+
+    /// A second resource type laying claim to `Value`'s marker.
+    struct Impostor;
+    impl OpaqueResource for Impostor {
+        type Marker = Marker;
+    }
+
+    #[test]
+    #[should_panic(expected = "is already registered for resource type")]
+    fn two_resource_types_under_one_marker_panic_at_registration() {
+        let (session, _) = session();
+        let _opaque = session.register(Value(42));
+        let _conflict = session.register(Impostor);
+    }
+
+    #[test]
+    fn a_citation_naming_a_differently_typed_entry_is_rejected() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let id = opaque.inner.id();
+        assert!(
+            session
+                .take_cite(WIRE_CITATION, id, TypeId::of::<Marker>())
+                .is_ok()
+        );
+        assert!(
+            session
+                .take_cite(WIRE_CITATION, id, TypeId::of::<OtherMarker>())
+                .is_err()
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "different session")]
+    fn redeeming_an_opaque_against_another_session_panics() {
+        let (first, _) = session();
+        let (second, _) = session();
+        let opaque = first.register(Value(42));
+        let _ = second.acquire::<Value>(cited(&first, &opaque));
+    }
+
+    #[test]
+    #[should_panic(expected = "different session")]
+    fn serializing_an_opaque_into_another_session_panics() {
+        let (first, _) = session();
+        let (second, _) = session();
+        let opaque = first.register(Value(42));
+        Ledger::default().put(&opaque.inner, &second);
+    }
+
     #[test]
     fn guards_outlive_registration() {
         let (session, _) = session();
         let opaque = session.register(Value(42));
-        let guard = session.acquire::<Value>(opaque.clone()).unwrap();
+        let guard = session.acquire::<Value>(cited(&session, &opaque)).unwrap();
         assert!(
             session
-                .unregister::<Value>(opaque.clone())
+                .unregister::<Value>(cited(&session, &opaque))
                 .unwrap()
                 .is_none()
         );
         assert_eq!(guard.0.0, 42);
-        assert!(session.acquire::<Value>(opaque).is_err());
+        assert!(session.acquire::<Value>(cited(&session, &opaque)).is_err());
     }
 
     #[test]
     fn unregister_returns_exclusively_owned_value() {
         let (session, _) = session();
         let opaque = session.register(Value(42));
-        let value = session.unregister::<Value>(opaque).unwrap().unwrap();
+        let value = session
+            .unregister::<Value>(cited(&session, &opaque))
+            .unwrap()
+            .unwrap();
         assert_eq!(value.0, 42);
     }
 
@@ -668,12 +973,16 @@ mod tests {
     fn wrong_type_does_not_remove_value() {
         let (session, _) = session();
         let opaque = session.register(Value(42));
-        let wrong: Opaque<OtherMarker> = Opaque {
-            inner: opaque.inner.clone(),
-            marker: PhantomData,
-        };
+        let wrong = Cite::<OtherMarker>::new(opaque.inner.clone());
         assert!(session.unregister::<OtherValue>(wrong).is_err());
-        assert_eq!(session.acquire::<Value>(opaque.clone()).unwrap().0.0, 42);
+        assert_eq!(
+            session
+                .acquire::<Value>(cited(&session, &opaque))
+                .unwrap()
+                .0
+                .0,
+            42
+        );
     }
 
     #[test]
@@ -698,7 +1007,7 @@ mod tests {
     fn a_gifted_entry_outlives_its_local_handle_until_released() {
         let (session, _) = session();
         let opaque = session.register(Value(42));
-        let Ref::Local(handle) = &opaque.inner else {
+        let Inner::Local(handle) = &opaque.inner else {
             unreachable!()
         };
         let escrow = session.gift(handle);
@@ -745,13 +1054,12 @@ mod tests {
     #[test]
     fn citing_an_opaque_has_no_protocol_effect() {
         let (session, recorder) = session();
-        let mirrored = session.take(WIRE_GIFT, 7).unwrap();
-        let opaque: Opaque<Marker> = Opaque {
-            inner: mirrored,
-            marker: PhantomData,
-        };
+        let opaque: Gift<Marker> = Gift::new(session.take_gift(WIRE_GIFT, 7).unwrap());
         let mut ledger = Ledger::default();
-        assert_eq!(ledger.put(&opaque.inner, &session), (WIRE_CITATION, 7));
+        assert_eq!(
+            ledger.put(&opaque.cite().inner, &session),
+            (WIRE_CITATION, 7)
+        );
         ledger.commit();
         // Still exactly the one reference the gift granted.
         drop(opaque);
@@ -761,14 +1069,8 @@ mod tests {
     #[test]
     fn repeated_gifts_of_one_id_accumulate_into_a_single_release() {
         let (session, recorder) = session();
-        let first: Opaque<Marker> = Opaque {
-            inner: session.take(WIRE_GIFT, 3).unwrap(),
-            marker: PhantomData,
-        };
-        let second: Opaque<Marker> = Opaque {
-            inner: session.take(WIRE_GIFT, 3).unwrap(),
-            marker: PhantomData,
-        };
+        let first: Gift<Marker> = Gift::new(session.take_gift(WIRE_GIFT, 3).unwrap());
+        let second: Gift<Marker> = Gift::new(session.take_gift(WIRE_GIFT, 3).unwrap());
         assert_eq!(first, second);
         drop(first);
         assert!(recorder.0.lock().unwrap().is_empty());
@@ -776,14 +1078,84 @@ mod tests {
         assert_eq!(*recorder.0.lock().unwrap(), vec![(3, 2)]);
     }
 
+    /// The owner bit is the peer's to choose, so a wire position declared to
+    /// hold one kind must refuse the other where the expectation is still
+    /// known — at decode, not at redemption.
     #[test]
-    fn a_citation_for_an_unknown_id_fails_to_acquire_rather_than_erroring() {
+    fn a_gift_in_a_citation_position_is_rejected() {
         let (session, _) = session();
-        let opaque: Opaque<Marker> = Opaque {
-            inner: session.take(WIRE_CITATION, 99).unwrap(),
-            marker: PhantomData,
-        };
-        assert!(session.acquire::<Value>(opaque).is_err());
+        let opaque = session.register(Value(42));
+        let id = opaque.inner.id();
+        assert!(
+            session
+                .take_cite(WIRE_GIFT, id, TypeId::of::<Marker>())
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn a_citation_in_a_gift_position_is_rejected() {
+        let (session, _) = session();
+        assert!(session.take_gift(WIRE_CITATION, 7).is_err());
+    }
+
+    /// A citation says "the reference you granted me", so pointing one at
+    /// one's own table is a local logic error rather than a protocol event.
+    #[test]
+    #[should_panic(expected = "cannot cite a resource this endpoint owns")]
+    fn citing_a_resource_this_endpoint_owns_panics() {
+        let (session, _) = session();
+        let _ = session.register(Value(42)).cite();
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot gift a resource this endpoint does not own")]
+    fn gifting_a_resource_the_peer_owns_panics() {
+        let (session, _) = session();
+        let mirrored: Gift<Marker> = Gift::new(session.take_gift(WIRE_GIFT, 7).unwrap());
+        let _ = postcard::to_allocvec(&mirrored);
+    }
+
+    /// The mirror image: a citation decoded on the owning side holds a local
+    /// handle, and putting it back on the wire would name it to a peer that
+    /// never granted it.
+    #[test]
+    #[should_panic(expected = "cannot cite a resource this endpoint owns")]
+    fn re_serializing_a_citation_that_came_home_panics() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let _ = postcard::to_allocvec(&cited(&session, &opaque));
+    }
+
+    #[test]
+    fn a_citation_for_an_unknown_id_is_rejected() {
+        let (session, _) = session();
+        assert!(
+            session
+                .take_cite(WIRE_CITATION, 99, TypeId::of::<Marker>())
+                .is_err()
+        );
+    }
+
+    /// The peer may still be citing a resource the owner has closed, so the
+    /// entry has to outlive the resource: emptied is a redemption failure,
+    /// absent is a protocol violation.
+    #[test]
+    fn a_citation_for_an_unregistered_but_still_granted_id_resolves() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let id = opaque.inner.id();
+        // Grant the peer a reference, as sending the opaque would.
+        Ledger::default().put(&opaque.inner, &session);
+        session
+            .unregister::<Value>(cited(&session, &opaque))
+            .unwrap();
+        let cite = Cite::<Marker>::new(
+            session
+                .take_cite(WIRE_CITATION, id, TypeId::of::<Marker>())
+                .unwrap(),
+        );
+        assert!(session.acquire::<Value>(cite).is_err());
     }
 
     #[test]
@@ -796,7 +1168,7 @@ mod tests {
             }))
             .is_err()
         );
-        assert!(std::panic::catch_unwind(|| postcard::from_bytes::<Opaque<Marker>>(&[0])).is_err());
+        assert!(std::panic::catch_unwind(|| postcard::from_bytes::<Gift<Marker>>(&[0])).is_err());
     }
 
     #[test]

--- a/dolang-rpc/src/session.rs
+++ b/dolang-rpc/src/session.rs
@@ -1,46 +1,221 @@
 //! Session-scoped opaque resources.
 //!
-//! [`Opaque`] is a serializable identity token for a resource retained by one
-//! endpoint. It can be redeemed only through that endpoint's
-//! [`CallContext`](crate::server::CallContext) while the resource remains
-//! registered.
+//! [`Opaque`] is a reference to a resource retained by one endpoint of a
+//! session. It can be redeemed only through that endpoint, and only while the
+//! resource remains registered.
+//!
+//! # Reference counting
+//!
+//! Opaques are counted at two independent levels, and conflating them is a
+//! bug:
+//!
+//! * The **protocol count** is per session table entry: how many references
+//!   the owner has handed the peer. The owner increments it when it serializes
+//!   a gift; the peer mirrors it when it deserializes one. Only a
+//!   [`Kind::Release`](crate::fragment::Kind::Release) moves it down.
+//! * The **local handle count** is the `Arc` inside [`Opaque`] itself: how
+//!   many live values in this process name the resource. Cloning an `Opaque`
+//!   grants the peer nothing, so it must not touch the protocol count — a
+//!   shared counter would inflate the eventual release by every local clone
+//!   and make the owner decrement more than it ever granted.
+//!
+//! Because the counts are plain totals rather than a handshake, a gift racing
+//! a release needs no generation number or echo. The owner goes 1 -> 2 -> 1
+//! while the peer goes 1 -> 0 -> 1, and both arrive at the same total whatever
+//! the interleaving.
+//!
+//! # Direction is load-bearing
+//!
+//! Serializing an opaque means one of two entirely different things depending
+//! on which side owns the resource:
+//!
+//! * A **gift** travels away from its owner (a response handing back a freshly
+//!   opened file). It grants the peer a reference, so it takes one.
+//! * A **citation** travels back toward its owner (`FileRead { file }`), which
+//!   is the hot path. It must have no protocol effect whatsoever. Citations
+//!   are safe unconditionally: the caller necessarily holds a reference for
+//!   the duration of the call it is citing the opaque in.
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+#[cfg(unix)]
+use std::os::fd::OwnedFd;
 use std::{
     any::{Any, TypeId},
     collections::HashMap,
-    fmt,
+    fmt, io,
     marker::PhantomData,
-    sync::Arc,
+    sync::{Arc, Mutex, Weak},
 };
+
+#[cfg(unix)]
+use crate::{handle::TakeHandle, transport::ReceivedHandles};
+use crate::{
+    handle::{ErasedHandle, PutHandle},
+    transport::EncodeHandles,
+};
+
+/// The owner bit rides the low bit of the id.
+pub(crate) fn pack_wire(owner: u8, id: u64) -> u64 {
+    debug_assert!(id < (1 << 63), "opaque identifier is too large to pack");
+    (id << 1) | u64::from(owner & 1)
+}
+
+pub(crate) fn unpack_wire(packed: u64) -> (u8, u64) {
+    ((packed & 1) as u8, packed >> 1)
+}
+
+/// Wire discriminant: the resource belongs to the sender.
+const WIRE_GIFT: u8 = 0;
+/// Wire discriminant: the resource belongs to the receiver.
+const WIRE_CITATION: u8 = 1;
 
 /// A value that can be registered in a session's opaque-object table.
 ///
 /// `Marker` is the public protocol-level type carried by [`Opaque`]. The
 /// concrete resource type may remain private. A marker does not by itself
-/// authorize a downcast:
-/// [`CallContext::acquire`](crate::server::CallContext::acquire)
-/// also verifies the concrete type.
+/// authorize a downcast: [`Session::acquire`] also verifies the concrete type.
 pub trait OpaqueResource: Send + Sync + 'static {
     type Marker: ?Sized + 'static;
 }
 
-/// A serializable, session-scoped reference to a registered resource.
+/// Emits release frames for opaques whose last local handle has dropped.
 ///
-/// This is an identity token, not the resource itself. It becomes invalid when
-/// its owner unregisters the resource or the session ends.
-#[derive(Serialize, Deserialize)]
-#[serde(bound = "")]
-pub struct Opaque<M: ?Sized> {
-    owner: u8,
+/// Implemented on each endpoint's `WeakUnboundedSender` for its own outgoing
+/// message type. Sending must not block or fail loudly: this is called from
+/// `Drop`. Deliberately weak: a writer task treats "every sender dropped" as
+/// its shutdown signal and transitively holds the `Session` that owns its
+/// sink, so a strong sender here would be a cycle — the writer waiting on a
+/// channel it is itself keeping open.
+pub(crate) trait ReleaseSink: Send + Sync + 'static {
+    fn release(&self, id: u64, count: u32);
+}
+
+/// A handle on a resource this endpoint owns.
+///
+/// The `Arc` around it is the local handle count. The resource itself lives in
+/// the session table, never in here, so that [`Session::unregister`] can empty
+/// the slot and have every outstanding `Opaque` observe the revocation. That
+/// is the whole reason [`Session::acquire`] is fallible: resolving an opaque is
+/// `open()` on a descriptor number, not a pointer dereference.
+pub(crate) struct LocalRef {
     id: u64,
+    session: Weak<Session>,
+}
+
+/// A handle on a resource the peer owns.
+///
+/// The protocol count lives in the table entry, not here: it is the total the
+/// peer has granted for the id, and whichever handle is alive owns that whole
+/// total. See [`RemoteRef::drop`] for how a handle that loses a race forfeits
+/// it rather than splitting it.
+pub(crate) struct RemoteRef {
+    id: u64,
+    session: Weak<Session>,
+}
+
+pub(crate) enum Ref {
+    Local(Arc<LocalRef>),
+    Remote(Arc<RemoteRef>),
+}
+
+impl Clone for Ref {
+    fn clone(&self) -> Self {
+        // Purely a local handle count bump; the protocol count is untouched.
+        match self {
+            Self::Local(local) => Self::Local(local.clone()),
+            Self::Remote(remote) => Self::Remote(remote.clone()),
+        }
+    }
+}
+
+impl Ref {
+    fn id(&self) -> u64 {
+        match self {
+            Self::Local(local) => local.id,
+            Self::Remote(remote) => remote.id,
+        }
+    }
+
+    fn owner(&self) -> u8 {
+        match self {
+            Self::Local(_) => WIRE_GIFT,
+            Self::Remote(_) => WIRE_CITATION,
+        }
+    }
+}
+
+impl Drop for LocalRef {
+    fn drop(&mut self) {
+        // A dead `Weak<Session>` means the connection itself is tearing down,
+        // which retires every table wholesale. Nothing to do.
+        let Some(session) = self.session.upgrade() else {
+            return;
+        };
+        let mut tables = session.tables.lock().unwrap();
+        let Some(entry) = tables.local.get(&self.id) else {
+            return;
+        };
+        // Only act if the entry still points at *us*: a citation that arrived
+        // while this handle was dying installed a fresh one (see `cite`), and
+        // that one now owns the registration.
+        if !entry.points_at(self) {
+            return;
+        }
+        // The peer may still name this resource even though we no longer hold
+        // a handle on it, in which case the entry (and the resource) has to
+        // outlive us and is retired by the final release instead.
+        if entry.granted == 0 {
+            tables.local.remove(&self.id);
+        }
+    }
+}
+
+impl Drop for RemoteRef {
+    fn drop(&mut self) {
+        let Some(session) = self.session.upgrade() else {
+            return;
+        };
+        let granted = {
+            let mut tables = session.tables.lock().unwrap();
+            // Only act if the slot still points at *us*. A gift that failed to
+            // upgrade this handle mid-drop installed a fresh one and folded
+            // our references into the entry's running total; that handle now
+            // owns the whole total, so this one releases nothing.
+            if !tables
+                .remote
+                .get(&self.id)
+                .is_some_and(|entry| entry.points_at(self))
+            {
+                return;
+            }
+            tables
+                .remote
+                .remove(&self.id)
+                .expect("just matched")
+                .granted
+        };
+        if granted > 0 {
+            session.sink.release(self.id, granted);
+        }
+    }
+}
+
+/// A session-scoped reference to a registered resource.
+///
+/// This is a reference, not the resource itself. It becomes invalid when its
+/// owner unregisters the resource or the session ends. Dropping the last
+/// `Opaque` naming a resource the peer owns releases the endpoint's references
+/// to it automatically — no explicit protocol close is required to avoid
+/// leaking it.
+pub struct Opaque<M: ?Sized> {
+    pub(crate) inner: Ref,
     marker: PhantomData<fn() -> M>,
 }
+
 impl<M: ?Sized> Clone for Opaque<M> {
     fn clone(&self) -> Self {
         Self {
-            owner: self.owner,
-            id: self.id,
+            inner: self.inner.clone(),
             marker: PhantomData,
         }
     }
@@ -48,7 +223,7 @@ impl<M: ?Sized> Clone for Opaque<M> {
 
 impl<M: ?Sized> PartialEq for Opaque<M> {
     fn eq(&self, other: &Self) -> bool {
-        self.owner == other.owner && self.id == other.id
+        self.inner.owner() == other.inner.owner() && self.inner.id() == other.inner.id()
     }
 }
 
@@ -57,9 +232,24 @@ impl<M: ?Sized> Eq for Opaque<M> {}
 impl<M: ?Sized> fmt::Debug for Opaque<M> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("Opaque")
-            .field("owner", &self.owner)
-            .field("id", &self.id)
+            .field("owner", &self.inner.owner())
+            .field("id", &self.inner.id())
             .finish_non_exhaustive()
+    }
+}
+
+impl<M: ?Sized> Serialize for Opaque<M> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        crate::serde::serialize_opaque(&self.inner, serializer)
+    }
+}
+
+impl<'de, M: ?Sized> Deserialize<'de> for Opaque<M> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        crate::serde::deserialize_opaque(deserializer).map(|inner| Opaque {
+            inner,
+            marker: PhantomData,
+        })
     }
 }
 
@@ -80,55 +270,335 @@ impl<T> std::ops::Deref for OpaqueGuard<T> {
 #[error("invalid opaque object")]
 pub struct InvalidOpaque;
 
-#[derive(Default)]
-pub(crate) struct ObjectTable {
-    next: u64,
-    values: HashMap<u64, (TypeId, Arc<dyn Any + Send + Sync>)>,
+struct LocalEntry {
+    ty: TypeId,
+    /// `None` once [`Session::unregister`] has emptied the handle. The entry
+    /// itself survives so that a citation still in flight from the peer is
+    /// distinguishable from an unknown id, and so the id cannot be reused
+    /// while the peer might still name it.
+    resource: Option<Arc<dyn Any + Send + Sync>>,
+    /// Protocol count: references handed to the peer.
+    granted: u32,
+    handle: Weak<LocalRef>,
 }
 
-impl ObjectTable {
-    pub fn register<T: OpaqueResource>(&mut self, value: T) -> Opaque<T::Marker> {
-        let id = self.next;
-        self.next = self
+impl LocalEntry {
+    fn points_at(&self, handle: &LocalRef) -> bool {
+        std::ptr::eq(self.handle.as_ptr(), handle as *const LocalRef)
+    }
+}
+
+struct RemoteEntry {
+    /// Protocol count: references the peer has granted for this id. Owned by
+    /// the entry rather than by any one handle, so a gift racing the last
+    /// handle's drop folds into a single running total.
+    granted: u32,
+    handle: Weak<RemoteRef>,
+}
+
+impl RemoteEntry {
+    fn points_at(&self, handle: &RemoteRef) -> bool {
+        std::ptr::eq(self.handle.as_ptr(), handle as *const RemoteRef)
+    }
+}
+
+#[derive(Default)]
+struct Tables {
+    next: u64,
+    local: HashMap<u64, LocalEntry>,
+    remote: HashMap<u64, RemoteEntry>,
+}
+
+/// One endpoint's half of a session's opaque bookkeeping.
+///
+/// Both endpoints run the same structure: `local` holds resources this side
+/// owns, `remote` mirrors references the peer has granted this side. A client
+/// that only ever receives opaques still needs `remote`, because dropping
+/// those references is what frees the peer's resources.
+pub(crate) struct Session {
+    tables: Mutex<Tables>,
+    sink: Box<dyn ReleaseSink>,
+}
+
+impl Session {
+    pub(crate) fn new(sink: Box<dyn ReleaseSink>) -> Arc<Self> {
+        Arc::new(Self {
+            tables: Mutex::new(Tables::default()),
+            sink,
+        })
+    }
+
+    pub(crate) fn register<T: OpaqueResource>(self: &Arc<Self>, value: T) -> Opaque<T::Marker> {
+        let mut tables = self.tables.lock().unwrap();
+        let id = tables.next;
+        tables.next = tables
             .next
             .checked_add(1)
             .expect("opaque identifiers exhausted");
-        self.values.insert(id, (TypeId::of::<T>(), Arc::new(value)));
-        Opaque {
-            owner: 1,
+        let handle = Arc::new(LocalRef {
             id,
+            session: Arc::downgrade(self),
+        });
+        tables.local.insert(
+            id,
+            LocalEntry {
+                ty: TypeId::of::<T>(),
+                resource: Some(Arc::new(value)),
+                granted: 0,
+                handle: Arc::downgrade(&handle),
+            },
+        );
+        Opaque {
+            inner: Ref::Local(handle),
             marker: PhantomData,
         }
     }
-    pub fn acquire<T: OpaqueResource>(
+
+    pub(crate) fn acquire<T: OpaqueResource>(
         &self,
         value: Opaque<T::Marker>,
     ) -> Result<OpaqueGuard<T>, InvalidOpaque> {
-        if value.owner != 1 {
+        let Ref::Local(local) = &value.inner else {
+            return Err(InvalidOpaque);
+        };
+        let tables = self.tables.lock().unwrap();
+        let entry = tables.local.get(&local.id).ok_or(InvalidOpaque)?;
+        if entry.ty != TypeId::of::<T>() {
             return Err(InvalidOpaque);
         }
-        let (ty, erased) = self.values.get(&value.id).ok_or(InvalidOpaque)?;
-        if *ty != TypeId::of::<T>() {
-            return Err(InvalidOpaque);
-        }
+        let resource = entry.resource.as_ref().ok_or(InvalidOpaque)?;
         Ok(OpaqueGuard(
-            erased.clone().downcast::<T>().map_err(|_| InvalidOpaque)?,
+            resource
+                .clone()
+                .downcast::<T>()
+                .map_err(|_| InvalidOpaque)?,
         ))
     }
-    pub fn unregister<T: OpaqueResource>(
-        &mut self,
+
+    /// Empties the handle, returning the resource if this call held the last
+    /// reference to it.
+    ///
+    /// The registration itself survives until the peer has released every
+    /// reference; only the resource slot is cleared. On the `None` path the
+    /// resource is *not* restored to the table — outstanding [`OpaqueGuard`]s
+    /// keep it alive and it dies with the last one. Restoring it would
+    /// resurrect the table's own reference so the resource outlived every
+    /// guard, silently turning a close that races an in-flight write into a
+    /// no-op; on a pipe's send end that is a missing EOF and a hung reader.
+    pub(crate) fn unregister<T: OpaqueResource>(
+        &self,
         value: Opaque<T::Marker>,
     ) -> Result<Option<T>, InvalidOpaque> {
-        if value.owner != 1 {
+        let Ref::Local(local) = &value.inner else {
+            return Err(InvalidOpaque);
+        };
+        let mut tables = self.tables.lock().unwrap();
+        let entry = tables.local.get_mut(&local.id).ok_or(InvalidOpaque)?;
+        if entry.ty != TypeId::of::<T>() {
             return Err(InvalidOpaque);
         }
-        let (ty, _) = self.values.get(&value.id).ok_or(InvalidOpaque)?;
-        if *ty != TypeId::of::<T>() {
-            return Err(InvalidOpaque);
+        let resource = entry.resource.take().ok_or(InvalidOpaque)?;
+        let resource = resource.downcast::<T>().map_err(|_| InvalidOpaque)?;
+        Ok(Arc::try_unwrap(resource).ok())
+    }
+
+    /// Applies a release frame from the peer. Unknown ids are ignored: a
+    /// consuming operation races the peer's release by construction.
+    pub(crate) fn release(&self, id: u64, count: u32) {
+        let mut tables = self.tables.lock().unwrap();
+        let Some(entry) = tables.local.get_mut(&id) else {
+            return;
+        };
+        entry.granted = entry.granted.saturating_sub(count);
+        if entry.granted == 0 && entry.handle.upgrade().is_none() {
+            tables.local.remove(&id);
         }
-        let (_, erased) = self.values.remove(&value.id).unwrap();
-        let value = erased.downcast::<T>().map_err(|_| InvalidOpaque)?;
-        Ok(Arc::try_unwrap(value).ok())
+    }
+
+    /// Records that a gift for `id` is being serialized, and returns the
+    /// escrow item holding the reference until the payload is committed.
+    fn gift(&self, handle: &Arc<LocalRef>) -> Escrowed {
+        let mut tables = self.tables.lock().unwrap();
+        if let Some(entry) = tables.local.get_mut(&handle.id) {
+            entry.granted += 1;
+        }
+        Escrowed::Gift(handle.clone())
+    }
+
+    /// Mirrors an arriving gift for `id`, merging into the handle this
+    /// endpoint already holds when there is one.
+    fn receive(self: &Arc<Self>, id: u64) -> Ref {
+        let mut tables = self.tables.lock().unwrap();
+        let session = Arc::downgrade(self);
+        let entry = tables.remote.entry(id).or_insert_with(|| RemoteEntry {
+            granted: 0,
+            handle: Weak::new(),
+        });
+        entry.granted += 1;
+        // A failed upgrade means the previous handle is mid-`Drop`. It will
+        // find the slot no longer pointing at it and leave the running total —
+        // including its own references and the one arriving now — to the fresh
+        // handle installed here.
+        if let Some(handle) = entry.handle.upgrade() {
+            return Ref::Remote(handle);
+        }
+        let handle = Arc::new(RemoteRef { id, session });
+        entry.handle = Arc::downgrade(&handle);
+        Ref::Remote(handle)
+    }
+
+    /// Resolves an arriving citation back to a handle on the resource this
+    /// endpoint owns.
+    ///
+    /// An unknown id yields a handle with no table entry rather than an error:
+    /// the peer may legitimately be citing something we have just retired, and
+    /// failing here would tear down the whole session over a benign race.
+    /// [`acquire`](Self::acquire) reports it as [`InvalidOpaque`] instead.
+    fn cite(self: &Arc<Self>, id: u64) -> Ref {
+        let mut tables = self.tables.lock().unwrap();
+        if let Some(entry) = tables.local.get_mut(&id) {
+            if let Some(handle) = entry.handle.upgrade() {
+                return Ref::Local(handle);
+            }
+            let handle = Arc::new(LocalRef {
+                id,
+                session: Arc::downgrade(self),
+            });
+            entry.handle = Arc::downgrade(&handle);
+            return Ref::Local(handle);
+        }
+        Ref::Local(Arc::new(LocalRef {
+            id,
+            session: Arc::downgrade(self),
+        }))
+    }
+
+    /// Resolves an arriving `(owner, id)` pair against this endpoint.
+    pub(crate) fn take(self: &Arc<Self>, owner: u8, id: u64) -> Result<Ref, InvalidOpaque> {
+        match owner {
+            // The sender owns it: a gift, which we mirror.
+            WIRE_GIFT => Ok(self.receive(id)),
+            // We own it: a citation coming home.
+            WIRE_CITATION => Ok(self.cite(id)),
+            _ => Err(InvalidOpaque),
+        }
+    }
+}
+
+/// A reference held on behalf of a message that is still being written.
+enum Escrowed {
+    /// A gift whose protocol increment is provisional until the payload is
+    /// fully written.
+    Gift(Arc<LocalRef>),
+    /// A citation. Never read: holding the `Arc` *is* the point, since that
+    /// is what keeps the last local handle alive and so orders any resulting
+    /// release strictly after the last payload fragment of the message that
+    /// cited it. Without it a small release frame could overtake a large body
+    /// under round-robin fragmentation, and the peer would retire the entry
+    /// before reassembling the message naming it.
+    Citation(#[allow(dead_code)] Arc<RemoteRef>),
+}
+
+/// The opaque references one outgoing message is holding.
+///
+/// Serializing moves references in here; the message's terminal outcome
+/// decides between [`commit`](Self::commit) and [`rescind`](Self::rescind).
+#[derive(Default)]
+pub(crate) struct Ledger {
+    items: Vec<Escrowed>,
+}
+
+impl Ledger {
+    /// Records an opaque encountered during serialization, returning its wire
+    /// `(owner, id)`.
+    pub(crate) fn put(&mut self, value: &Ref, session: &Arc<Session>) -> (u8, u64) {
+        match value {
+            Ref::Local(local) => {
+                self.items.push(session.gift(local));
+                (WIRE_GIFT, local.id)
+            }
+            Ref::Remote(remote) => {
+                self.items.push(Escrowed::Citation(remote.clone()));
+                (WIRE_CITATION, remote.id)
+            }
+        }
+    }
+
+    /// The payload was fully written, so every gift in it is irrevocably
+    /// transmitted. Dropping the citations here is what orders any release
+    /// they were suppressing after the message that cited them.
+    pub(crate) fn commit(self) {
+        // Every held reference drops here, on the far side of the payload.
+    }
+
+    /// The message was abandoned before its payload completed, so the peer
+    /// cannot have decoded it and no gift in it ever landed.
+    ///
+    /// Only ever correct for an abort that precedes payload completion.
+    /// Guessing "delivered" when it was not strands a reference until the
+    /// session ends; guessing "not delivered" when it was leaves the peer
+    /// holding a freed handle. Leak beats corruption.
+    pub(crate) fn rescind(self) {
+        for item in &self.items {
+            let Escrowed::Gift(handle) = item else {
+                continue;
+            };
+            let Some(session) = handle.session.upgrade() else {
+                continue;
+            };
+            let mut tables = session.tables.lock().unwrap();
+            if let Some(entry) = tables.local.get_mut(&handle.id) {
+                entry.granted = entry.granted.saturating_sub(1);
+            }
+        }
+    }
+}
+
+/// Wraps a transport's handle sink with the session context an [`Opaque`]
+/// needs, so that serialization has exactly one threaded context rather than
+/// two parallel ones.
+pub(crate) struct SessionFrame<'a> {
+    pub(crate) inner: EncodeHandles,
+    pub(crate) session: &'a Arc<Session>,
+    pub(crate) ledger: &'a mut Ledger,
+}
+
+impl PutHandle for SessionFrame<'_> {
+    #[cfg(unix)]
+    fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<u32> {
+        self.inner.put_handle(handle)
+    }
+
+    #[cfg(windows)]
+    fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<usize> {
+        self.inner.put_handle(handle)
+    }
+
+    fn put_opaque(&mut self, opaque: &Ref) -> io::Result<(u8, u64)> {
+        Ok(self.ledger.put(opaque, self.session))
+    }
+}
+
+/// The deserialization counterpart of [`SessionFrame`].
+#[cfg(unix)]
+pub(crate) struct SessionHandles<'a> {
+    pub(crate) inner: ReceivedHandles,
+    pub(crate) session: &'a Arc<Session>,
+}
+
+#[cfg(unix)]
+impl TakeHandle for SessionHandles<'_> {
+    fn take_handle(&mut self, index: u32) -> io::Result<OwnedFd> {
+        self.inner.take_handle(index)
+    }
+
+    fn finish(&mut self) -> io::Result<()> {
+        self.inner.finish()
+    }
+    fn take_opaque(&mut self, owner: u8, id: u64) -> io::Result<Ref> {
+        self.session
+            .take(owner, id)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidData, "invalid opaque reference"))
     }
 }
 
@@ -136,6 +606,21 @@ impl ObjectTable {
 mod tests {
     use super::*;
     use std::sync::atomic::{AtomicBool, Ordering};
+
+    #[derive(Default)]
+    struct Recorder(Mutex<Vec<(u64, u32)>>);
+    impl ReleaseSink for Arc<Recorder> {
+        fn release(&self, id: u64, count: u32) {
+            self.0.lock().unwrap().push((id, count));
+        }
+    }
+
+    /// A session whose emitted releases the test can inspect.
+    fn session() -> (Arc<Session>, Arc<Recorder>) {
+        let recorder = Arc::new(Recorder::default());
+        (Session::new(Box::new(recorder.clone())), recorder)
+    }
+
     struct Marker;
     struct OtherMarker;
     struct Value(u32);
@@ -158,41 +643,174 @@ mod tests {
 
     #[test]
     fn guards_outlive_registration() {
-        let mut table = ObjectTable::default();
-        let opaque = table.register(Value(42));
-        let guard = table.acquire::<Value>(opaque.clone()).unwrap();
-        assert!(table.unregister::<Value>(opaque.clone()).unwrap().is_none());
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let guard = session.acquire::<Value>(opaque.clone()).unwrap();
+        assert!(
+            session
+                .unregister::<Value>(opaque.clone())
+                .unwrap()
+                .is_none()
+        );
         assert_eq!(guard.0.0, 42);
-        assert!(table.acquire::<Value>(opaque).is_err());
+        assert!(session.acquire::<Value>(opaque).is_err());
     }
 
     #[test]
     fn unregister_returns_exclusively_owned_value() {
-        let mut table = ObjectTable::default();
-        let opaque = table.register(Value(42));
-        let value = table.unregister::<Value>(opaque).unwrap().unwrap();
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let value = session.unregister::<Value>(opaque).unwrap().unwrap();
         assert_eq!(value.0, 42);
     }
 
     #[test]
     fn wrong_type_does_not_remove_value() {
-        let mut table = ObjectTable::default();
-        let opaque = table.register(Value(42));
-        let wrong = Opaque::<OtherMarker> {
-            owner: opaque.owner,
-            id: opaque.id,
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let wrong: Opaque<OtherMarker> = Opaque {
+            inner: opaque.inner.clone(),
             marker: PhantomData,
         };
-        assert!(table.unregister::<OtherValue>(wrong).is_err());
-        assert_eq!(table.acquire::<Value>(opaque).unwrap().0.0, 42);
+        assert!(session.unregister::<OtherValue>(wrong).is_err());
+        assert_eq!(session.acquire::<Value>(opaque.clone()).unwrap().0.0, 42);
     }
 
     #[test]
-    fn dropping_table_drops_registered_values() {
+    fn dropping_session_drops_registered_values() {
         let dropped = Arc::new(AtomicBool::new(false));
-        let mut table = ObjectTable::default();
-        table.register(DropValue(dropped.clone()));
-        drop(table);
+        let (session, _) = session();
+        let opaque = session.register(DropValue(dropped.clone()));
+        drop(opaque);
+        drop(session);
         assert!(dropped.load(Ordering::Relaxed));
+    }
+
+    #[test]
+    fn dropping_the_last_local_handle_retires_an_ungifted_entry() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        drop(opaque);
+        assert!(session.tables.lock().unwrap().local.is_empty());
+    }
+
+    #[test]
+    fn a_gifted_entry_outlives_its_local_handle_until_released() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let Ref::Local(handle) = &opaque.inner else {
+            unreachable!()
+        };
+        let escrow = session.gift(handle);
+        drop(escrow);
+        drop(opaque);
+        // The peer still holds the reference, so the resource must survive.
+        assert_eq!(session.tables.lock().unwrap().local.len(), 1);
+        session.release(0, 1);
+        assert!(session.tables.lock().unwrap().local.is_empty());
+    }
+
+    #[test]
+    fn cloning_an_opaque_does_not_grant_a_protocol_reference() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let clones: Vec<_> = (0..8).map(|_| opaque.clone()).collect();
+        assert_eq!(session.tables.lock().unwrap().local[&0].granted, 0);
+        drop(clones);
+        drop(opaque);
+        assert!(session.tables.lock().unwrap().local.is_empty());
+    }
+
+    #[test]
+    fn rescinding_undoes_the_gift_increment() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let mut ledger = Ledger::default();
+        assert_eq!(ledger.put(&opaque.inner, &session), (WIRE_GIFT, 0));
+        assert_eq!(session.tables.lock().unwrap().local[&0].granted, 1);
+        ledger.rescind();
+        assert_eq!(session.tables.lock().unwrap().local[&0].granted, 0);
+    }
+
+    #[test]
+    fn committing_leaves_the_gift_increment_in_place() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        let mut ledger = Ledger::default();
+        ledger.put(&opaque.inner, &session);
+        ledger.commit();
+        assert_eq!(session.tables.lock().unwrap().local[&0].granted, 1);
+    }
+
+    #[test]
+    fn citing_an_opaque_has_no_protocol_effect() {
+        let (session, recorder) = session();
+        let mirrored = session.take(WIRE_GIFT, 7).unwrap();
+        let opaque: Opaque<Marker> = Opaque {
+            inner: mirrored,
+            marker: PhantomData,
+        };
+        let mut ledger = Ledger::default();
+        assert_eq!(ledger.put(&opaque.inner, &session), (WIRE_CITATION, 7));
+        ledger.commit();
+        // Still exactly the one reference the gift granted.
+        drop(opaque);
+        assert_eq!(*recorder.0.lock().unwrap(), vec![(7, 1)]);
+    }
+
+    #[test]
+    fn repeated_gifts_of_one_id_accumulate_into_a_single_release() {
+        let (session, recorder) = session();
+        let first: Opaque<Marker> = Opaque {
+            inner: session.take(WIRE_GIFT, 3).unwrap(),
+            marker: PhantomData,
+        };
+        let second: Opaque<Marker> = Opaque {
+            inner: session.take(WIRE_GIFT, 3).unwrap(),
+            marker: PhantomData,
+        };
+        assert_eq!(first, second);
+        drop(first);
+        assert!(recorder.0.lock().unwrap().is_empty());
+        drop(second);
+        assert_eq!(*recorder.0.lock().unwrap(), vec![(3, 2)]);
+    }
+
+    #[test]
+    fn a_citation_for_an_unknown_id_fails_to_acquire_rather_than_erroring() {
+        let (session, _) = session();
+        let opaque: Opaque<Marker> = Opaque {
+            inner: session.take(WIRE_CITATION, 99).unwrap(),
+            marker: PhantomData,
+        };
+        assert!(session.acquire::<Value>(opaque).is_err());
+    }
+
+    #[test]
+    fn plain_postcard_use_panics() {
+        let (session, _) = session();
+        let opaque = session.register(Value(42));
+        assert!(
+            std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                postcard::to_allocvec(&opaque)
+            }))
+            .is_err()
+        );
+        assert!(std::panic::catch_unwind(|| postcard::from_bytes::<Opaque<Marker>>(&[0])).is_err());
+    }
+
+    #[test]
+    fn wire_form_survives_packing_both_owners() {
+        for owner in [WIRE_GIFT, WIRE_CITATION] {
+            for id in [0, 1, 42, u32::MAX as u64, (1 << 62) - 1] {
+                assert_eq!(unpack_wire(pack_wire(owner, id)), (owner, id));
+            }
+        }
+    }
+
+    #[test]
+    fn releasing_an_unknown_id_is_ignored() {
+        let (session, _) = session();
+        session.release(1234, 5);
     }
 }

--- a/dolang-rpc/src/trailer.rs
+++ b/dolang-rpc/src/trailer.rs
@@ -516,7 +516,7 @@ impl<T: Unpin> AsyncWrite for TrailerSend<T> {
                     .min(inner.max_trailer_size - inner.written);
                 if len <= inner.copy_threshold {
                     FragmentHeader {
-                        flags: Flags::TRAILER,
+                        flags: Flags::NONE,
                         kind: inner.kind,
                         id: inner.id,
                         payload_len: len,
@@ -554,7 +554,7 @@ impl<T: Unpin> AsyncWrite for TrailerSend<T> {
                     .min(inner.max_fragment_size.max(1))
                     .min(inner.max_trailer_size - inner.written);
                 FragmentHeader {
-                    flags: Flags::TRAILER,
+                    flags: Flags::NONE,
                     kind: inner.kind,
                     id: inner.id,
                     payload_len: len,
@@ -579,7 +579,7 @@ impl<T: Unpin> AsyncWrite for TrailerSend<T> {
                     .min(inner.max_fragment_size.max(1))
                     .min(inner.max_trailer_size - inner.written);
                 FragmentHeader {
-                    flags: Flags::TRAILER,
+                    flags: Flags::NONE,
                     kind: inner.kind,
                     id: inner.id,
                     payload_len: len,
@@ -1225,7 +1225,7 @@ mod tests {
             Poll::Ready(Ok(4))
         ));
         let header = FragmentHeader {
-            flags: Flags::TRAILER,
+            flags: Flags::NONE,
             kind: Kind::Request,
             id: 1,
             payload_len: 4,
@@ -1358,7 +1358,7 @@ mod tests {
         {
             let inner = lock(&shared);
             let header_len = FragmentHeader {
-                flags: Flags::TRAILER,
+                flags: Flags::NONE,
                 kind: Kind::Request,
                 id: 1,
                 payload_len: data.len(),
@@ -1374,7 +1374,7 @@ mod tests {
             SendAction::Abort
         );
         let header_len = FragmentHeader {
-            flags: Flags::TRAILER,
+            flags: Flags::NONE,
             kind: Kind::Request,
             id: 1,
             payload_len: data.len(),
@@ -1414,7 +1414,7 @@ mod tests {
         assert_eq!(written, data.len());
 
         let header = FragmentHeader {
-            flags: Flags::TRAILER,
+            flags: Flags::NONE,
             kind: Kind::Request,
             id: 7,
             payload_len: data.len(),

--- a/dolang-rpc/src/transport/unix.rs
+++ b/dolang-rpc/src/transport/unix.rs
@@ -16,15 +16,15 @@ use nix::{
 use tokio::io::unix::AsyncFd;
 
 use super::{AnySender, Receiver, RecvFrame, SendFrame, Sender};
-use crate::handle::{ErasedHandle, PutHandle, TakeHandle};
+use crate::handle::ErasedHandle;
 
-pub(crate) struct EncodeHandles<'handle> {
-    handles: Vec<&'handle dyn ErasedHandle>,
+pub(crate) struct EncodeHandles {
+    handles: Vec<OwnedFd>,
     max_handles: usize,
     supported: bool,
 }
 
-impl<'handle> EncodeHandles<'handle> {
+impl EncodeHandles {
     pub(crate) fn new(sender: &AnySender, max_handles: usize) -> Self {
         Self {
             handles: Vec::new(),
@@ -34,11 +34,7 @@ impl<'handle> EncodeHandles<'handle> {
     }
 
     pub(crate) fn finish(self) -> OutgoingHandles {
-        let fds: Vec<_> = self
-            .handles
-            .into_iter()
-            .map(ErasedHandle::steal_handle)
-            .collect();
+        let fds = self.handles;
         #[cfg(target_os = "macos")]
         let escrow = !fds.is_empty();
         OutgoingHandles {
@@ -58,8 +54,8 @@ impl<'handle> EncodeHandles<'handle> {
     }
 }
 
-impl<'handle> PutHandle<'handle> for EncodeHandles<'handle> {
-    fn put_handle(&mut self, handle: &'handle dyn ErasedHandle) -> io::Result<u32> {
+impl EncodeHandles {
+    pub(crate) fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<u32> {
         if !self.supported {
             return Err(io::Error::new(
                 io::ErrorKind::Unsupported,
@@ -72,17 +68,13 @@ impl<'handle> PutHandle<'handle> for EncodeHandles<'handle> {
                 "message contains too many handle attachments",
             ));
         }
-        if self
-            .handles
-            .iter()
-            .any(|existing| std::ptr::eq(*existing, handle))
-        {
-            return Err(io::Error::new(
+        let index = u32::try_from(self.handles.len()).unwrap();
+        let handle = handle.steal_handle().ok_or_else(|| {
+            io::Error::new(
                 io::ErrorKind::InvalidData,
                 "the same handle was serialized more than once",
-            ));
-        }
-        let index = u32::try_from(self.handles.len()).unwrap();
+            )
+        })?;
         self.handles.push(handle);
         Ok(index)
     }
@@ -125,8 +117,8 @@ impl ReceivedHandles {
     }
 }
 
-impl TakeHandle for ReceivedHandles {
-    fn take_handle(&mut self, index: u32) -> io::Result<OwnedFd> {
+impl ReceivedHandles {
+    pub(crate) fn take_handle(&mut self, index: u32) -> io::Result<OwnedFd> {
         let index = usize::try_from(index).unwrap();
         self.fds
             .get_mut(index)
@@ -145,7 +137,7 @@ impl TakeHandle for ReceivedHandles {
             })
     }
 
-    fn finish(&mut self) -> io::Result<()> {
+    pub(crate) fn finish(&mut self) -> io::Result<()> {
         if self.fds.iter().any(Option::is_some) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/dolang-rpc/src/transport/windows.rs
+++ b/dolang-rpc/src/transport/windows.rs
@@ -16,15 +16,15 @@ use windows_sys::Win32::{
 };
 
 use super::{AnyAttachments, AnySender, Receiver, RecvFrame, SendFrame, Sender};
-use crate::handle::{ErasedHandle, PutHandle};
+use crate::handle::ErasedHandle;
 
-pub(crate) struct EncodeHandles<'handle> {
-    handles: Vec<&'handle dyn ErasedHandle>,
+pub(crate) struct EncodeHandles {
+    handles: Vec<OwnedHandle>,
     max_handles: usize,
     attachments: AnyAttachments,
 }
 
-impl<'handle> EncodeHandles<'handle> {
+impl EncodeHandles {
     pub(crate) fn new(sender: &AnySender, max_handles: usize) -> Self {
         Self {
             handles: Vec::new(),
@@ -34,11 +34,7 @@ impl<'handle> EncodeHandles<'handle> {
     }
 
     pub(crate) fn finish(self) -> (OutgoingHandles, Vec<OwnedHandle>) {
-        let escrow = self
-            .handles
-            .into_iter()
-            .map(ErasedHandle::steal_handle)
-            .collect();
+        let escrow = self.handles;
         match self.attachments {
             AnyAttachments::Generic => {}
             AnyAttachments::Windows(attachments) => attachments.finish(),
@@ -47,32 +43,29 @@ impl<'handle> EncodeHandles<'handle> {
     }
 }
 
-impl<'handle> PutHandle<'handle> for EncodeHandles<'handle> {
-    fn put_handle(&mut self, handle: &'handle dyn ErasedHandle) -> io::Result<usize> {
+impl EncodeHandles {
+    pub(crate) fn put_handle(&mut self, handle: &dyn ErasedHandle) -> io::Result<usize> {
         if self.handles.len() == self.max_handles {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidData,
                 "message contains too many handle attachments",
             ));
         }
-        if self
-            .handles
-            .iter()
-            .any(|existing| std::ptr::eq(*existing, handle))
-        {
+        if matches!(self.attachments, AnyAttachments::Generic) {
             return Err(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "the same handle was serialized more than once",
+                io::ErrorKind::Unsupported,
+                "generic byte-stream transport does not support handle attachments",
             ));
         }
+        let handle = handle.steal_handle().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                "the same handle was serialized more than once",
+            )
+        })?;
         let value = match &mut self.attachments {
-            AnyAttachments::Generic => {
-                return Err(io::Error::new(
-                    io::ErrorKind::Unsupported,
-                    "generic byte-stream transport does not support handle attachments",
-                ));
-            }
-            AnyAttachments::Windows(attachments) => attachments.attach(handle.raw_handle())?,
+            AnyAttachments::Generic => unreachable!(),
+            AnyAttachments::Windows(attachments) => attachments.attach(handle.as_raw_handle())?,
         };
         self.handles.push(handle);
         Ok(value)

--- a/dolang-rpc/tests/dolang_rpc/session.rs
+++ b/dolang-rpc/tests/dolang_rpc/session.rs
@@ -1225,3 +1225,37 @@ async fn a_claimed_gift_lives_exactly_as_long_as_the_caller_holds_it() {
         "the endpoint outlived the caller's last handle on it"
     );
 }
+
+/// Releasing an opaque must not need an ambient runtime. The caller's last
+/// handle on a gift routinely falls out of scope during teardown, after the
+/// runtime that carried the session is already gone, and a release that
+/// reached for `Handle::current` there would panic in a destructor.
+#[test]
+fn dropping_a_claimed_gift_outside_a_runtime_does_not_panic() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .unwrap();
+    let (endpoint, client, server) = runtime.block_on(async {
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let guarded = Arc::new(tokio::sync::Notify::new());
+        let respond_now = Arc::new(tokio::sync::Notify::new());
+        let server = serve_gifts(
+            server_io,
+            Arc::new(AtomicBool::new(false)),
+            guarded.clone(),
+            respond_now.clone(),
+        );
+        let client = unbound_client::<_, Gifts>(client_io).await;
+        let call = client.call(GiftRequest);
+        guarded.notified().await;
+        respond_now.notify_one();
+        let response = call.await.unwrap().into_response();
+        (response.endpoint, client, server)
+    });
+
+    drop(runtime);
+    drop(endpoint);
+    drop(client);
+    drop(server);
+}

--- a/dolang-rpc/tests/dolang_rpc/session.rs
+++ b/dolang-rpc/tests/dolang_rpc/session.rs
@@ -13,7 +13,7 @@ use dolang_rpc::{
     Builder, Error, Protocol,
     client::Client,
     server::CallContext,
-    session::{Opaque, OpaqueResource},
+    session::{Gift, OpaqueResource},
 };
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
@@ -1083,7 +1083,7 @@ struct GiftRequest;
 
 #[derive(Serialize, Deserialize)]
 struct GiftResponse {
-    endpoint: Opaque<EndpointMarker>,
+    endpoint: Gift<EndpointMarker>,
 }
 
 struct EndpointMarker;

--- a/dolang-rpc/tests/dolang_rpc/session.rs
+++ b/dolang-rpc/tests/dolang_rpc/session.rs
@@ -9,7 +9,12 @@ use std::{
     time::Duration,
 };
 
-use dolang_rpc::{Builder, Error, Protocol, client::Client, server::CallContext};
+use dolang_rpc::{
+    Builder, Error, Protocol,
+    client::Client,
+    server::CallContext,
+    session::{Opaque, OpaqueResource},
+};
 use serde::{Deserialize, Serialize};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -1063,4 +1068,160 @@ mod windows_handles {
         let mut byte = [0];
         received.read_exact(&mut byte).unwrap();
     }
+}
+
+/// A protocol whose response hands the caller an opaque, used to pin down what
+/// happens to that opaque when nobody is left to receive it.
+struct Gifts;
+impl Protocol for Gifts {
+    type Request = GiftRequest;
+    type Response = GiftResponse;
+}
+
+#[derive(Serialize, Deserialize)]
+struct GiftRequest;
+
+#[derive(Serialize, Deserialize)]
+struct GiftResponse {
+    endpoint: Opaque<EndpointMarker>,
+}
+
+struct EndpointMarker;
+
+/// A registered resource that reports its own death.
+struct Endpoint(Arc<AtomicBool>);
+
+impl OpaqueResource for Endpoint {
+    type Marker = EndpointMarker;
+}
+
+impl Drop for Endpoint {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::SeqCst);
+    }
+}
+
+async fn wait_for(flag: &AtomicBool) -> bool {
+    for _ in 0..200 {
+        if flag.load(Ordering::SeqCst) {
+            return true;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    false
+}
+
+/// Serves `Gifts`, registering an [`Endpoint`] per request that flips
+/// `dropped` when it dies.
+///
+/// The handler waits to be released by `respond_now` from inside a cancel
+/// guard, so a caller can abandon the call and still be sure the response gets
+/// built and sent: an unguarded cancel would simply abort the handler, and
+/// there would be no gift to lose track of in the first place.
+fn serve_gifts<T>(
+    server_io: T,
+    dropped: Arc<AtomicBool>,
+    guarded: Arc<tokio::sync::Notify>,
+    respond_now: Arc<tokio::sync::Notify>,
+) -> tokio::task::JoinHandle<()>
+where
+    T: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    tokio::spawn(async move {
+        let _ = builder()
+            .server(server_io)
+            .await
+            .unwrap()
+            .bind::<Gifts>()
+            .serve(async move |mut context, _request: GiftRequest| {
+                let _ = context
+                    .cancel_guard(async |_| {
+                        guarded.notify_one();
+                        respond_now.notified().await;
+                    })
+                    .await;
+                let endpoint = context.register(Endpoint(dropped.clone()));
+                context.respond(GiftResponse { endpoint });
+            })
+            .await;
+    })
+}
+
+/// The bug this whole branch exists for: a caller that walks away from a call
+/// whose response carries a gift used to strand the resource for the life of
+/// the connection.
+///
+/// Nothing in the application ever sees the response — the reader task decodes
+/// it and drops it — so releasing it is entirely the session's job. Note what
+/// this implies about the decode: skipping it for a response nobody is waiting
+/// on would look like an optimization and would silently reintroduce the leak.
+#[tokio::test]
+async fn a_cancelled_call_releases_the_gift_in_its_response() {
+    let (client_io, server_io) = tokio::io::duplex(4096);
+    let dropped = Arc::new(AtomicBool::new(false));
+    let guarded = Arc::new(tokio::sync::Notify::new());
+    let respond_now = Arc::new(tokio::sync::Notify::new());
+    let _server = serve_gifts(
+        server_io,
+        dropped.clone(),
+        guarded.clone(),
+        respond_now.clone(),
+    );
+    // Kept alive for the whole test: the release travels over this connection,
+    // so closing it early would prove nothing.
+    let client = unbound_client::<_, Gifts>(client_io).await;
+
+    let call = client.call(GiftRequest);
+    guarded.notified().await;
+    drop(call);
+    respond_now.notify_one();
+
+    assert!(
+        wait_for(&dropped).await,
+        "the endpoint in an abandoned response was never released"
+    );
+}
+
+/// The same resource, claimed normally: it must survive until the caller is
+/// actually done with it, and die once the caller drops it.
+#[tokio::test]
+async fn a_claimed_gift_lives_exactly_as_long_as_the_caller_holds_it() {
+    let (client_io, server_io) = tokio::io::duplex(4096);
+    let dropped = Arc::new(AtomicBool::new(false));
+    let guarded = Arc::new(tokio::sync::Notify::new());
+    let respond_now = Arc::new(tokio::sync::Notify::new());
+    let _server = serve_gifts(
+        server_io,
+        dropped.clone(),
+        guarded.clone(),
+        respond_now.clone(),
+    );
+    let client = unbound_client::<_, Gifts>(client_io).await;
+
+    let call = client.call(GiftRequest);
+    guarded.notified().await;
+    respond_now.notify_one();
+    let response = call.await.unwrap().into_response();
+
+    // A clone is a local handle, not a second protocol reference; the resource
+    // must outlive it and every other copy the caller makes.
+    let clone = response.endpoint.clone();
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "the endpoint died while the caller still held it"
+    );
+
+    drop(response);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    assert!(
+        !dropped.load(Ordering::SeqCst),
+        "the endpoint died while a clone of the caller's handle was still live"
+    );
+
+    drop(clone);
+    assert!(
+        wait_for(&dropped).await,
+        "the endpoint outlived the caller's last handle on it"
+    );
 }

--- a/dolang-vfs-winreg/src/api.rs
+++ b/dolang-vfs-winreg/src/api.rs
@@ -7,7 +7,7 @@
 //! implementation detail, same as `dolang-vfs` never exposing its own
 //! `RequestKind`/`ResponseKind`/`VfsProtocol`.
 
-use dolang_vfs::extension::{ExtOpaque, VfsExtension};
+use dolang_vfs::extension::{ExtCite, ExtGift, VfsExtension};
 use dolang_vfs::{
     AnyVfs, Vfs,
     direct::Direct,
@@ -47,7 +47,7 @@ fn unexpected(request: &str) -> Error {
 /// chain of same-machine keys: every subsequent operation on the returned
 /// `Key` (including opening its own subkeys) is dispatched through that
 /// `AnyVfs::Direct`, which is itself always `native_capable() == false`, so
-/// it always takes the ordinary in-process [`ExtOpaque`] path from then on.
+/// it always takes the ordinary in-process [`ExtGift`] path from then on.
 async fn from_response(
     vfs: &AnyVfs,
     request: &str,
@@ -90,24 +90,25 @@ pub struct Key {
 
 struct KeyState {
     vfs: AnyVfs,
-    opaque: Option<ExtOpaque<KeyMarker>>,
+    opaque: Option<ExtGift<KeyMarker>>,
 }
 
 impl KeyState {
-    fn new(vfs: AnyVfs, opaque: ExtOpaque<KeyMarker>) -> Self {
+    fn new(vfs: AnyVfs, opaque: ExtGift<KeyMarker>) -> Self {
         Self {
             vfs,
             opaque: Some(opaque),
         }
     }
 
-    fn opaque(&self) -> Result<ExtOpaque<KeyMarker>, Error> {
+    fn cite(&self) -> Result<ExtCite<KeyMarker>, Error> {
         self.opaque
-            .clone()
+            .as_ref()
+            .map(ExtGift::cite)
             .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "registry key is closed"))
     }
 
-    fn take_opaque(&mut self) -> ExtOpaque<KeyMarker> {
+    fn take_opaque(&mut self) -> ExtGift<KeyMarker> {
         self.opaque.take().expect("live key state has no opaque")
     }
 }
@@ -123,7 +124,7 @@ impl Drop for KeyState {
         let vfs = self.vfs.clone();
         runtime.spawn(async move {
             let _ = vfs
-                .call_extension::<WinRegExt>(WinRegRequest::CloseKey { key })
+                .call_extension::<WinRegExt>(WinRegRequest::CloseKey { key: key.cite() })
                 .await;
         });
     }
@@ -158,7 +159,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::OpenKey {
-                parent: self.handle.opaque()?,
+                parent: self.handle.cite()?,
                 subpath: subpath.to_string(),
                 view,
                 access,
@@ -173,7 +174,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::CreateKey {
-                parent: self.handle.opaque()?,
+                parent: self.handle.cite()?,
                 subpath: subpath.to_string(),
                 view,
                 access,
@@ -194,7 +195,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::DeleteKey {
-                parent: self.handle.opaque()?,
+                parent: self.handle.cite()?,
                 subpath: subpath.to_string(),
                 view,
                 all,
@@ -221,7 +222,7 @@ impl Key {
                 "registry key has an operation in progress",
             )
         })?;
-        let key = state.take_opaque();
+        let key = state.take_opaque().cite();
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::CloseKey { key })
@@ -237,7 +238,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::EnumSubkey {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 index,
             })
             .await??;
@@ -252,7 +253,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::OpenSubkeys {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
             })
             .await??;
         match response {
@@ -273,7 +274,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::EnumValue {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 index,
             })
             .await??;
@@ -288,7 +289,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::OpenValues {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
             })
             .await??;
         match response {
@@ -309,7 +310,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::GetValue {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 name: name.map(str::to_string),
             })
             .await??;
@@ -324,7 +325,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::SetValue {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 name: name.map(str::to_string),
                 value,
             })
@@ -340,7 +341,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::DeleteValue {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 name: name.map(str::to_string),
             })
             .await??;
@@ -363,7 +364,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::GetSecDesc {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 mask,
             })
             .await??;
@@ -385,7 +386,7 @@ impl Key {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::SetSecDesc {
-                key: self.handle.opaque()?,
+                key: self.handle.cite()?,
                 sec_desc: descriptor.clone(),
             })
             .await??;
@@ -420,7 +421,7 @@ impl SubKeys {
             .key
             .upgrade()
             .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "registry key is closed"))?;
-        key.opaque()?;
+        key.cite()?;
         if let Some(entry) = self.entries.pop_front() {
             return Ok(Some(entry));
         }
@@ -430,7 +431,7 @@ impl SubKeys {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::EnumSubkeysPage {
-                key: key.opaque()?,
+                key: key.cite()?,
                 index: self.index,
                 count: PAGE_SIZE,
             })
@@ -469,7 +470,7 @@ impl Values {
             .key
             .upgrade()
             .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "registry key is closed"))?;
-        key.opaque()?;
+        key.cite()?;
         if let Some(entry) = self.entries.pop_front() {
             return Ok(Some(entry));
         }
@@ -479,7 +480,7 @@ impl Values {
         let response = self
             .vfs
             .call_extension::<WinRegExt>(WinRegRequest::EnumValuesPage {
-                key: key.opaque()?,
+                key: key.cite()?,
                 index: self.index,
                 count: PAGE_SIZE,
             })

--- a/dolang-vfs-winreg/src/wire.rs
+++ b/dolang-vfs-winreg/src/wire.rs
@@ -6,7 +6,7 @@
 //! (de)serialize through the VFS extension mechanism.
 
 use dolang_vfs::error::Error;
-use dolang_vfs::extension::{ExtContext, ExtOpaque, ExtOsHandle, VfsExtension};
+use dolang_vfs::extension::{ExtCite, ExtContext, ExtGift, ExtOsHandle, VfsExtension};
 use dolang_winterop::security::SecDesc;
 use serde::{Deserialize, Serialize};
 
@@ -25,11 +25,11 @@ pub(crate) struct KeyMarker;
 /// then operate on it directly through a local [`dolang_vfs::direct::Direct`]
 /// VFS, without any further RPC round trips. See
 /// [`WinRegRequest::AdoptNative`] for how a `Native` handle is turned back
-/// into an [`ExtOpaque`].
+/// into an [`ExtGift`].
 #[derive(Serialize, Deserialize)]
 pub(crate) enum KeyHandle {
     Native(ExtOsHandle),
-    Opaque(ExtOpaque<KeyMarker>),
+    Opaque(ExtGift<KeyMarker>),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -92,76 +92,76 @@ pub(crate) enum WinRegRequest {
         access: Access,
     },
     OpenKey {
-        parent: ExtOpaque<KeyMarker>,
+        parent: ExtCite<KeyMarker>,
         subpath: String,
         view: View,
         access: Access,
     },
     CreateKey {
-        parent: ExtOpaque<KeyMarker>,
+        parent: ExtCite<KeyMarker>,
         subpath: String,
         view: View,
         access: Access,
     },
     CloseKey {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
     },
     DeleteKey {
-        parent: ExtOpaque<KeyMarker>,
+        parent: ExtCite<KeyMarker>,
         subpath: String,
         view: View,
         all: bool,
         ignore: bool,
     },
     EnumSubkey {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         index: u32,
     },
     OpenSubkeys {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
     },
     EnumSubkeysPage {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         index: u32,
         count: u32,
     },
     EnumValue {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         index: u32,
     },
     OpenValues {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
     },
     EnumValuesPage {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         index: u32,
         count: u32,
     },
     GetValue {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         name: Option<String>,
     },
     SetValue {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         name: Option<String>,
         value: Value,
     },
     DeleteValue {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         name: Option<String>,
     },
     GetSecDesc {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         mask: u32,
     },
     SetSecDesc {
-        key: ExtOpaque<KeyMarker>,
+        key: ExtCite<KeyMarker>,
         sec_desc: SecDesc,
     },
     /// Adopts a native handle received out-of-band (see [`KeyHandle`]) back
-    /// into a registered [`ExtOpaque`].
+    /// into a registered [`ExtGift`].
     ///
-    /// Producing an `ExtOpaque` requires an [`ExtContext`], which only
+    /// Producing an `ExtGift` requires an [`ExtContext`], which only
     /// exists inside a `VfsExtension::handle` call — so a client that
     /// receives `KeyHandle::Native` self-dispatches this request against a
     /// local, direct [`dolang_vfs::AnyVfs::Direct`] purely to reach

--- a/dolang-vfs-winscm/src/api.rs
+++ b/dolang-vfs-winscm/src/api.rs
@@ -7,7 +7,7 @@
 //! `dolang-vfs` never exposing its own `RequestKind`/`ResponseKind`/
 //! `VfsProtocol`.
 
-use dolang_vfs::extension::{ExtOpaque, VfsExtension};
+use dolang_vfs::extension::{ExtCite, ExtGift, VfsExtension};
 use dolang_vfs::{
     AnyVfs, Vfs,
     error::{Error, ErrorKind},
@@ -43,24 +43,25 @@ pub struct ScManager {
 
 struct ScManagerState {
     vfs: AnyVfs,
-    opaque: Option<ExtOpaque<ScManagerMarker>>,
+    opaque: Option<ExtGift<ScManagerMarker>>,
 }
 
 impl ScManagerState {
-    fn new(vfs: AnyVfs, opaque: ExtOpaque<ScManagerMarker>) -> Self {
+    fn new(vfs: AnyVfs, opaque: ExtGift<ScManagerMarker>) -> Self {
         Self {
             vfs,
             opaque: Some(opaque),
         }
     }
 
-    fn opaque(&self) -> Result<ExtOpaque<ScManagerMarker>, Error> {
+    fn cite(&self) -> Result<ExtCite<ScManagerMarker>, Error> {
         self.opaque
-            .clone()
+            .as_ref()
+            .map(ExtGift::cite)
             .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "SC manager is closed"))
     }
 
-    fn take_opaque(&mut self) -> ExtOpaque<ScManagerMarker> {
+    fn take_opaque(&mut self) -> ExtGift<ScManagerMarker> {
         self.opaque
             .take()
             .expect("live manager state has no opaque")
@@ -78,7 +79,9 @@ impl Drop for ScManagerState {
         let vfs = self.vfs.clone();
         runtime.spawn(async move {
             let _ = vfs
-                .call_extension::<WinScmExt>(WinScmRequest::CloseManager { manager })
+                .call_extension::<WinScmExt>(WinScmRequest::CloseManager {
+                    manager: manager.cite(),
+                })
                 .await;
         });
     }
@@ -114,7 +117,7 @@ impl ScManager {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::OpenService {
-                manager: self.handle.opaque()?,
+                manager: self.handle.cite()?,
                 name: name.to_string(),
                 access,
             })
@@ -170,7 +173,7 @@ impl ScManager {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::CreateService {
-                manager: self.handle.opaque()?,
+                manager: self.handle.cite()?,
                 name: name.to_string(),
                 display_name: display_name.map(str::to_owned),
                 service_type,
@@ -221,7 +224,7 @@ impl ScManager {
                 "SC manager has an operation in progress",
             )
         })?;
-        let manager = state.take_opaque();
+        let manager = state.take_opaque().cite();
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::CloseManager { manager })
@@ -251,7 +254,7 @@ impl Services {
             .manager
             .upgrade()
             .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "SC manager is closed"))?;
-        manager.opaque()?;
+        manager.cite()?;
         if let Some(entry) = self.entries.pop_front() {
             return Ok(Some(entry));
         }
@@ -261,7 +264,7 @@ impl Services {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::EnumServicesPage {
-                manager: manager.opaque()?,
+                manager: manager.cite()?,
                 service_type: self.service_type,
                 state_filter: self.state_filter,
                 resume: self.resume,
@@ -285,7 +288,7 @@ impl Services {
 /// An open handle to a specific service.
 pub struct Service {
     vfs: AnyVfs,
-    handle: ExtOpaque<ServiceMarker>,
+    handle: ExtGift<ServiceMarker>,
 }
 
 impl Service {
@@ -295,7 +298,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::DeleteService {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
             })
             .await??;
         match response {
@@ -314,7 +317,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::CloseService {
-                service: self.handle,
+                service: self.handle.cite(),
             })
             .await??;
         match response {
@@ -333,7 +336,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::StartService {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
                 args: args.to_vec(),
             })
             .await??;
@@ -349,7 +352,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::ControlService {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
                 control,
             })
             .await??;
@@ -364,7 +367,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::QueryStatus {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
             })
             .await??;
         match response {
@@ -378,7 +381,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::QueryConfig {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
             })
             .await??;
         match response {
@@ -392,7 +395,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::ChangeConfig {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
                 update,
             })
             .await??;
@@ -417,7 +420,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::GetSecDesc {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
                 mask,
             })
             .await??;
@@ -440,7 +443,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::SetSecDesc {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
                 sec_desc: descriptor.clone(),
             })
             .await??;
@@ -462,7 +465,7 @@ impl Service {
         let response = self
             .vfs
             .call_extension::<WinScmExt>(WinScmRequest::WaitForStatusChange {
-                service: self.handle.clone(),
+                service: self.handle.cite(),
                 mask,
             })
             .await??;

--- a/dolang-vfs-winscm/src/wire.rs
+++ b/dolang-vfs-winscm/src/wire.rs
@@ -9,7 +9,7 @@
 //! route and (de)serialize through the VFS extension mechanism.
 
 use dolang_vfs::error::Error;
-use dolang_vfs::extension::{ExtContext, ExtOpaque, VfsExtension};
+use dolang_vfs::extension::{ExtCite, ExtContext, ExtGift, VfsExtension};
 use dolang_winterop::security::SecDesc;
 use serde::{Deserialize, Serialize};
 
@@ -293,15 +293,15 @@ pub(crate) enum WinScmRequest {
         access: ServiceAccess,
     },
     CloseManager {
-        manager: ExtOpaque<ScManagerMarker>,
+        manager: ExtCite<ScManagerMarker>,
     },
     OpenService {
-        manager: ExtOpaque<ScManagerMarker>,
+        manager: ExtCite<ScManagerMarker>,
         name: String,
         access: ServiceAccess,
     },
     CreateService {
-        manager: ExtOpaque<ScManagerMarker>,
+        manager: ExtCite<ScManagerMarker>,
         name: String,
         display_name: Option<String>,
         service_type: ServiceType,
@@ -312,53 +312,53 @@ pub(crate) enum WinScmRequest {
         access: ServiceAccess,
     },
     EnumServicesPage {
-        manager: ExtOpaque<ScManagerMarker>,
+        manager: ExtCite<ScManagerMarker>,
         service_type: ServiceType,
         state_filter: ServiceStateFilter,
         resume: u32,
     },
     DeleteService {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
     },
     CloseService {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
     },
     StartService {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
         args: Vec<String>,
     },
     ControlService {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
         control: ServiceControl,
     },
     QueryStatus {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
     },
     QueryConfig {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
     },
     ChangeConfig {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
         update: ServiceConfigUpdate,
     },
     WaitForStatusChange {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
         mask: NotifyMask,
     },
     GetSecDesc {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
         mask: u32,
     },
     SetSecDesc {
-        service: ExtOpaque<ServiceMarker>,
+        service: ExtCite<ServiceMarker>,
         sec_desc: SecDesc,
     },
 }
 
 #[derive(Serialize, Deserialize)]
 pub(crate) enum WinScmResponse {
-    Manager(ExtOpaque<ScManagerMarker>),
-    Svc(ExtOpaque<ServiceMarker>),
+    Manager(ExtGift<ScManagerMarker>),
+    Svc(ExtGift<ServiceMarker>),
     Closed,
     Deleted,
     Ack,

--- a/dolang-vfs/src/client/mod.rs
+++ b/dolang-vfs/src/client/mod.rs
@@ -88,7 +88,7 @@ enum ClientFileInner {
 
 struct RemoteFile {
     client: Client,
-    file: Option<Opaque<crate::session::FileMarker>>,
+    file: Opaque<crate::session::FileMarker>,
     pending: Option<PendingFileOperation>,
     read_body: Option<PendingTrailerRead>,
     write_body: Option<PendingTrailerWrite>,
@@ -202,7 +202,7 @@ impl ClientFile {
     fn from_remote(client: Client, file: Opaque<crate::session::FileMarker>) -> Self {
         Self(ClientFileInner::Remote(RemoteFile {
             client,
-            file: Some(file),
+            file,
             pending: None,
             read_body: None,
             write_body: None,
@@ -212,10 +212,7 @@ impl ClientFile {
 
 impl RemoteFile {
     fn opaque(&self) -> Opaque<crate::session::FileMarker> {
-        self.file
-            .as_ref()
-            .expect("live remote file has no opaque identity")
-            .clone()
+        self.file.clone()
     }
 
     fn poll_request(
@@ -285,22 +282,6 @@ impl RemoteFile {
             pending.call.cancel();
             let _ = pending.call.await;
         }
-    }
-}
-
-impl Drop for RemoteFile {
-    fn drop(&mut self) {
-        self.pending.take();
-        let Some(file) = self.file.take() else {
-            return;
-        };
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let client = self.client.clone();
-        runtime.spawn(async move {
-            let _ = client.request(RequestKind::FileClose { file }).await;
-        });
     }
 }
 
@@ -616,13 +597,9 @@ impl FileHandle for ClientFile {
             ClientFileInner::Direct(file) => file.close().await,
             ClientFileInner::Remote(mut file) => {
                 file.cancel_pending().await;
-                let opaque = file
-                    .file
-                    .take()
-                    .expect("live remote file has no opaque identity");
                 match file
                     .client
-                    .request(RequestKind::FileClose { file: opaque })
+                    .request(RequestKind::FileClose { file: file.file })
                     .await?
                 {
                     ResponseKind::FileClose(result) => result.map_err(Into::into),
@@ -2021,18 +1998,10 @@ impl ClientChild {
 
 impl Drop for ClientChild {
     fn drop(&mut self) {
+        // Reaping the child is the opaque's own business: dropping the last
+        // handle on it releases the registration, which drops the retained
+        // child on the server. Only the relays need winding down here.
         self.relays.finish();
-        let ClientChildState::Live(child) = &self.state else {
-            return;
-        };
-        let child = child.clone();
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let client = self.client.clone();
-        runtime.spawn(async move {
-            let _ = client.request(RequestKind::ChildClose { child }).await;
-        });
     }
 }
 
@@ -2945,13 +2914,8 @@ impl Vfs for Client {
 mod tests {
     use std::io;
 
-    use tempfile::tempdir;
-
-    use super::{Client, ClientChildState, ClientFileInner};
-    use crate::{
-        Child as _, Command as _, FileHandle as _, OpenOptions, Server, Vfs as _,
-        protocol::RequestKind,
-    };
+    use super::{Client, ClientChildState};
+    use crate::{Child as _, Command as _, Server, Vfs as _, protocol::RequestKind};
 
     #[cfg(unix)]
     fn successful_command(client: &Client) -> super::CommandBuilder<'_> {
@@ -2968,100 +2932,6 @@ mod tests {
         ));
         command.arg("/C").arg("exit 0");
         command
-    }
-
-    async fn open_remote_file(
-        client: &Client,
-        path: crate::Utf8TypedPath<'_>,
-    ) -> super::ClientFile {
-        let mut options = client.open_options();
-        options.read(true).write(true).create(true).truncate(true);
-        crate::OpenOptions::open(&options, path).await.unwrap()
-    }
-
-    #[tokio::test]
-    async fn dropping_remote_file_unregisters_opaque_identity() {
-        let (client_stream, server_stream) = tokio::io::duplex(1024 * 1024);
-        let server =
-            tokio::spawn(async move { Server::new(server_stream).await.unwrap().serve().await });
-        let client = Client::new(client_stream).await.unwrap();
-        let temp = tempdir().unwrap();
-        let path = crate::path::typed_path(temp.path().join("file")).unwrap();
-        let file = open_remote_file(&client, path.to_path()).await;
-        let opaque = match &file.0 {
-            ClientFileInner::Remote(file) => file.opaque(),
-            ClientFileInner::Direct(_) => panic!("remote open returned a direct file"),
-        };
-
-        drop(file);
-
-        for attempt in 0..100 {
-            let response = client
-                .request(RequestKind::FileMetadata {
-                    file: opaque.clone(),
-                })
-                .await
-                .unwrap();
-            let crate::protocol::ResponseKind::FileMetadata(result) = response else {
-                panic!("file metadata returned the wrong response");
-            };
-            match result {
-                Err(error) => {
-                    assert_eq!(
-                        crate::Error::from(error).kind(),
-                        io::ErrorKind::InvalidInput
-                    );
-                    break;
-                }
-                Ok(_) if attempt < 99 => tokio::task::yield_now().await,
-                Ok(_) => panic!("dropped opaque file remained registered"),
-            }
-        }
-
-        client.stop().await.unwrap();
-        server.await.unwrap().unwrap();
-    }
-
-    #[test]
-    fn dropping_remote_file_without_runtime_does_not_panic() {
-        let runtime = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .unwrap();
-        let (file, client, server, temp) = runtime.block_on(async {
-            let (client_stream, server_stream) = tokio::io::duplex(1024 * 1024);
-            let server =
-                tokio::spawn(
-                    async move { Server::new(server_stream).await.unwrap().serve().await },
-                );
-            let client = Client::new(client_stream).await.unwrap();
-            let temp = tempdir().unwrap();
-            let path = crate::path::typed_path(temp.path().join("file")).unwrap();
-            let file = open_remote_file(&client, path.to_path()).await;
-            (file, client, server, temp)
-        });
-
-        drop(runtime);
-        drop(file);
-        drop(client);
-        drop(server);
-        drop(temp);
-    }
-
-    #[tokio::test]
-    async fn explicit_close_consumes_remote_cleanup_identity() {
-        let (client_stream, server_stream) = tokio::io::duplex(1024 * 1024);
-        let server =
-            tokio::spawn(async move { Server::new(server_stream).await.unwrap().serve().await });
-        let client = Client::new(client_stream).await.unwrap();
-        let temp = tempdir().unwrap();
-        let path = crate::path::typed_path(temp.path().join("file")).unwrap();
-        let file = open_remote_file(&client, path.to_path()).await;
-
-        file.close().await.unwrap();
-
-        client.stop().await.unwrap();
-        server.await.unwrap().unwrap();
     }
 
     #[tokio::test]

--- a/dolang-vfs/src/client/mod.rs
+++ b/dolang-vfs/src/client/mod.rs
@@ -20,7 +20,7 @@ use std::os::windows::io::{AsHandle, OwnedHandle};
 use dolang_rpc::{
     client::Call,
     handle::{DefaultHandle, OsHandle},
-    session::Opaque,
+    session::{Cite, Gift},
     trailer::{TrailerRecv, TrailerSend},
 };
 use dolang_winterop::security::{SecDesc, Sid};
@@ -65,7 +65,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Client {
     shared: Arc<ClientShared>,
-    vfs: Option<Opaque<crate::session::VfsMarker>>,
+    vfs: Option<Gift<crate::session::VfsMarker>>,
 }
 
 struct ClientShared {
@@ -88,7 +88,7 @@ enum ClientFileInner {
 
 struct RemoteFile {
     client: Client,
-    file: Opaque<crate::session::FileMarker>,
+    file: Gift<crate::session::FileMarker>,
     pending: Option<PendingFileOperation>,
     read_body: Option<PendingTrailerRead>,
     write_body: Option<PendingTrailerWrite>,
@@ -96,7 +96,7 @@ struct RemoteFile {
 
 pub(crate) struct RemoteFileLock {
     client: Client,
-    file: Opaque<crate::session::FileMarker>,
+    file: Gift<crate::session::FileMarker>,
     lock: Option<u64>,
 }
 
@@ -108,7 +108,7 @@ impl RemoteFileLock {
         match self
             .client
             .request(RequestKind::FileUnlock {
-                file: self.file.clone(),
+                file: self.file.cite(),
                 lock,
             })
             .await?
@@ -132,7 +132,7 @@ impl Drop for RemoteFileLock {
             return;
         };
         let client = self.client.clone();
-        let file = self.file.clone();
+        let file = self.file.cite();
         runtime.spawn(async move {
             let _ = client.request(RequestKind::FileUnlock { file, lock }).await;
         });
@@ -199,7 +199,7 @@ impl ClientFile {
         )))
     }
 
-    fn from_remote(client: Client, file: Opaque<crate::session::FileMarker>) -> Self {
+    fn from_remote(client: Client, file: Gift<crate::session::FileMarker>) -> Self {
         Self(ClientFileInner::Remote(RemoteFile {
             client,
             file,
@@ -211,18 +211,18 @@ impl ClientFile {
 }
 
 impl RemoteFile {
-    fn opaque(&self) -> Opaque<crate::session::FileMarker> {
-        self.file.clone()
+    fn cite(&self) -> Cite<crate::session::FileMarker> {
+        self.file.cite()
     }
 
     fn poll_request(
         &mut self,
         cx: &mut Context<'_>,
         kind: FileOperationKind,
-        request: impl FnOnce(Opaque<crate::session::FileMarker>) -> (RequestKind, Option<Vec<u8>>),
+        request: impl FnOnce(Cite<crate::session::FileMarker>) -> (RequestKind, Option<Vec<u8>>),
     ) -> Poll<io::Result<(ResponseKind, Option<TrailerRecv>)>> {
         if self.pending.is_none() {
-            let (request, trailer) = request(self.opaque());
+            let (request, trailer) = request(self.cite());
             self.pending = Some(PendingFileOperation {
                 kind,
                 call: {
@@ -379,9 +379,10 @@ impl AsyncWrite for ClientFile {
                 }
                 if file.write_body.is_none() {
                     file.write_body = Some(PendingTrailerWrite {
-                        send: Some(file.client.call_with_trailer(RequestKind::FileWrite {
-                            file: file.opaque(),
-                        })),
+                        send: Some(
+                            file.client
+                                .call_with_trailer(RequestKind::FileWrite { file: file.cite() }),
+                        ),
                         call: None,
                         target: buf.len(),
                         sent: 0,
@@ -501,7 +502,7 @@ impl AsyncSeek for ClientFile {
                 file.pending = Some(PendingFileOperation {
                     kind: FileOperationKind::Seek,
                     call: file.client.call(RequestKind::FileSeek {
-                        file: file.opaque(),
+                        file: file.cite(),
                         position: position.into(),
                     }),
                 });
@@ -543,9 +544,7 @@ impl FileHandle for ClientFile {
                 file.idle()?;
                 match file
                     .client
-                    .request(RequestKind::FileToStdioSend {
-                        file: file.opaque(),
-                    })
+                    .request(RequestKind::FileToStdioSend { file: file.cite() })
                     .await?
                 {
                     ResponseKind::FileToStdioSend(result) => result
@@ -571,9 +570,7 @@ impl FileHandle for ClientFile {
                 file.idle()?;
                 match file
                     .client
-                    .request(RequestKind::FileToStdioRecv {
-                        file: file.opaque(),
-                    })
+                    .request(RequestKind::FileToStdioRecv { file: file.cite() })
                     .await?
                 {
                     ResponseKind::FileToStdioRecv(result) => result
@@ -599,7 +596,9 @@ impl FileHandle for ClientFile {
                 file.cancel_pending().await;
                 match file
                     .client
-                    .request(RequestKind::FileClose { file: file.file })
+                    .request(RequestKind::FileClose {
+                        file: file.file.cite(),
+                    })
                     .await?
                 {
                     ResponseKind::FileClose(result) => result.map_err(Into::into),
@@ -617,7 +616,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileSetSize {
-                        file: file.opaque(),
+                        file: file.cite(),
                         size,
                     })
                     .await?
@@ -636,9 +635,7 @@ impl FileHandle for ClientFile {
                 file.idle()?;
                 match file
                     .client
-                    .request(RequestKind::FileMetadata {
-                        file: file.opaque(),
-                    })
+                    .request(RequestKind::FileMetadata { file: file.cite() })
                     .await?
                 {
                     ResponseKind::FileMetadata(result) => result.map_err(Into::into),
@@ -655,9 +652,7 @@ impl FileHandle for ClientFile {
                 file.idle()?;
                 match file
                     .client
-                    .request(RequestKind::FileFsMetadata {
-                        file: file.opaque(),
-                    })
+                    .request(RequestKind::FileFsMetadata { file: file.cite() })
                     .await?
                 {
                     ResponseKind::FileFsMetadata(result) => result.map_err(Into::into),
@@ -675,7 +670,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileAcl {
-                        file: file.opaque(),
+                        file: file.cite(),
                         default,
                     })
                     .await?
@@ -695,7 +690,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileSetAcl {
-                        file: file.opaque(),
+                        file: file.cite(),
                         acl: acl.cloned(),
                         default,
                     })
@@ -716,7 +711,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileSecDesc {
-                        file: file.opaque(),
+                        file: file.cite(),
                         mask,
                     })
                     .await?
@@ -736,7 +731,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileSetSecDesc {
-                        file: file.opaque(),
+                        file: file.cite(),
                         sec_desc: sec_desc.clone(),
                     })
                     .await?
@@ -759,7 +754,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileXattrs {
-                        file: file.opaque(),
+                        file: file.cite(),
                         namespace: XattrNamespaceRequest::from(namespace),
                     })
                     .await?
@@ -779,7 +774,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileXattr {
-                        file: file.opaque(),
+                        file: file.cite(),
                         name: name.to_owned(),
                         namespace: namespace.map(str::to_owned),
                     })
@@ -799,9 +794,7 @@ impl FileHandle for ClientFile {
                 file.idle()?;
                 match file
                     .client
-                    .request(RequestKind::FileStreams {
-                        file: file.opaque(),
-                    })
+                    .request(RequestKind::FileStreams { file: file.cite() })
                     .await?
                 {
                     ResponseKind::FileStreams(result) => result.map_err(Into::into),
@@ -824,7 +817,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileSetXattr {
-                        file: file.opaque(),
+                        file: file.cite(),
                         name: name.to_owned(),
                         namespace: namespace.map(str::to_owned),
                         value: value.to_vec(),
@@ -846,7 +839,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileRemoveXattr {
-                        file: file.opaque(),
+                        file: file.cite(),
                         name: name.to_owned(),
                         namespace: namespace.map(str::to_owned),
                     })
@@ -870,7 +863,7 @@ impl FileHandle for ClientFile {
                 match file
                     .client
                     .request(RequestKind::FileLock {
-                        file: file.opaque(),
+                        file: file.cite(),
                         request,
                     })
                     .await?
@@ -880,7 +873,7 @@ impl FileHandle for ClientFile {
                             lock.map(|lock| {
                                 crate::file::FileLock::remote(RemoteFileLock {
                                     client: file.client.clone(),
-                                    file: file.opaque(),
+                                    file: file.file.clone(),
                                     lock: Some(lock),
                                 })
                             })
@@ -930,11 +923,11 @@ impl Client {
     async fn initialize(
         rpc: dolang_rpc::client::Client<VfsProtocol>,
         mode: SessionMode,
-        vfs: Option<Opaque<crate::session::VfsMarker>>,
+        vfs: Option<Gift<crate::session::VfsMarker>>,
     ) -> crate::Result<Self> {
         let response = rpc
             .call(Request {
-                vfs: vfs.clone(),
+                vfs: vfs.as_ref().map(Gift::cite),
                 kind: RequestKind::Query,
             })
             .await
@@ -1063,14 +1056,14 @@ impl Client {
 
     fn call(&self, request: RequestKind) -> Call<VfsProtocol> {
         self.shared.rpc.call(Request {
-            vfs: self.vfs.clone(),
+            vfs: self.vfs.as_ref().map(Gift::cite),
             kind: request,
         })
     }
 
     fn call_with_trailer(&self, request: RequestKind) -> TrailerSend<Call<VfsProtocol>> {
         self.shared.rpc.call_with_trailer(Request {
-            vfs: self.vfs.clone(),
+            vfs: self.vfs.as_ref().map(Gift::cite),
             kind: request,
         })
     }
@@ -1425,7 +1418,7 @@ struct PreparedRelays {
 }
 
 enum ClientChildState {
-    Live(Opaque<crate::session::ChildMarker>),
+    Live(Gift<crate::session::ChildMarker>),
     Exited(ProcessStatus),
     Lost(crate::protocol::WireError),
 }
@@ -1436,7 +1429,7 @@ enum ClientChildState {
 /// closes the corresponding remote endpoint.
 pub struct RemoteStdioSend {
     client: Client,
-    stdio: Option<Opaque<crate::session::StdioSendMarker>>,
+    stdio: Option<Gift<crate::session::StdioSendMarker>>,
     pending: Option<(StdioSendOperation, Call<VfsProtocol>)>,
     write_body: Option<PendingTrailerWrite>,
 }
@@ -1446,7 +1439,7 @@ pub struct RemoteStdioSend {
 /// This implements [`AsyncRead`].
 pub struct RemoteStdioRecv {
     client: Client,
-    stdio: Option<Opaque<crate::session::StdioRecvMarker>>,
+    stdio: Option<Gift<crate::session::StdioRecvMarker>>,
     pending: Option<Call<VfsProtocol>>,
     read_body: Option<PendingTrailerRead>,
 }
@@ -1489,7 +1482,7 @@ impl AsyncWrite for RemoteStdioSend {
             )));
         }
         if self.write_body.is_none() {
-            let Some(stdio) = self.stdio.as_ref().cloned() else {
+            let Some(stdio) = self.stdio.as_ref().map(Gift::cite) else {
                 return Poll::Ready(Err(io::Error::new(
                     io::ErrorKind::BrokenPipe,
                     "stdio send resource is closed",
@@ -1590,7 +1583,7 @@ impl AsyncWrite for RemoteStdioSend {
             return Poll::Ready(Ok(()));
         }
         if self.pending.is_none() {
-            let stdio = self.stdio.as_ref().unwrap().clone();
+            let stdio = self.stdio.as_ref().unwrap().cite();
             self.pending = Some((
                 StdioSendOperation::Close,
                 self.client.call(RequestKind::StdioSendClose { stdio }),
@@ -1664,7 +1657,7 @@ impl AsyncRead for RemoteStdioRecv {
                     return Poll::Ready(Ok(()));
                 };
                 self.pending = Some(self.client.call(RequestKind::StdioRecvRead {
-                    stdio: stdio.clone(),
+                    stdio: stdio.cite(),
                     len: buf.remaining(),
                 }));
             }
@@ -1718,7 +1711,7 @@ impl RemoteStdioSend {
         match self
             .client
             .request(RequestKind::StdioSendClone {
-                stdio: stdio.clone(),
+                stdio: stdio.cite(),
             })
             .await
             .map_err(crate::Error::into_io_error)?
@@ -1756,7 +1749,7 @@ impl RemoteStdioRecv {
         match self
             .client
             .request(RequestKind::StdioRecvClone {
-                stdio: stdio.clone(),
+                stdio: stdio.cite(),
             })
             .await
             .map_err(crate::Error::into_io_error)?
@@ -1853,7 +1846,7 @@ impl<'a> CommandBuilder<'a> {
             .into());
         }
         Ok(StdioRecvTarget::Opaque(
-            remote.stdio.as_ref().unwrap().clone(),
+            remote.stdio.as_ref().unwrap().cite(),
         ))
     }
 
@@ -1906,7 +1899,7 @@ impl<'a> CommandBuilder<'a> {
             .into());
         }
         Ok(StdioSendTarget::Opaque(
-            remote.stdio.as_ref().unwrap().clone(),
+            remote.stdio.as_ref().unwrap().cite(),
         ))
     }
 
@@ -2016,7 +2009,7 @@ impl Child for ClientChild {
         match self
             .client
             .request(RequestKind::ChildWait {
-                child: child.clone(),
+                child: child.cite(),
             })
             .await?
         {
@@ -2040,7 +2033,7 @@ impl Child for ClientChild {
         match self
             .client
             .request(RequestKind::ChildTerminate {
-                child: child.clone(),
+                child: child.cite(),
             })
             .await?
         {
@@ -2946,7 +2939,7 @@ mod tests {
         };
         let response = client
             .request(RequestKind::ChildClose {
-                child: opaque.clone(),
+                child: opaque.cite(),
             })
             .await
             .unwrap();

--- a/dolang-vfs/src/client/mod.rs
+++ b/dolang-vfs/src/client/mod.rs
@@ -3045,7 +3045,6 @@ mod tests {
     use std::io;
 
     use tempfile::tempdir;
-    use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
 
     use super::{Client, ClientChildState, ClientFileInner};
     use crate::{
@@ -3120,131 +3119,6 @@ mod tests {
 
         client.stop().await.unwrap();
         server.await.unwrap().unwrap();
-    }
-
-    #[tokio::test]
-    async fn opaque_pipe_rejects_wrong_type_and_stale_identity() {
-        let (client_stream, server_stream) = tokio::io::duplex(1024 * 1024);
-        let server =
-            tokio::spawn(async move { Server::new(server_stream).await.unwrap().serve().await });
-        let client = Client::new(client_stream).await.unwrap();
-        let (mut send, mut recv) = client.pipe().await.unwrap();
-        let send_opaque = match &send {
-            crate::StdioSend::Remote(send) => send.stdio.as_ref().unwrap().clone(),
-            crate::StdioSend::Native(_) => panic!("remote pipe returned a native send end"),
-        };
-
-        let encoded = postcard::to_allocvec(&send_opaque).unwrap();
-        let wrong: dolang_rpc::session::Opaque<crate::session::StdioRecvMarker> =
-            postcard::from_bytes(&encoded).unwrap();
-        let response = client
-            .request(RequestKind::StdioRecvClose { stdio: wrong })
-            .await
-            .unwrap();
-        let crate::protocol::ResponseKind::StdioRecvClose(result) = response else {
-            panic!("stdio receive close returned the wrong response");
-        };
-        assert_eq!(
-            crate::Error::from(result.unwrap_err()).kind(),
-            io::ErrorKind::InvalidInput
-        );
-
-        send.write_all(b"still live").await.unwrap();
-        let mut data = [0; 10];
-        recv.read_exact(&mut data).await.unwrap();
-        assert_eq!(&data, b"still live");
-        send.shutdown().await.unwrap();
-
-        let response = client
-            .request(RequestKind::StdioSendClose { stdio: send_opaque })
-            .await
-            .unwrap();
-        let crate::protocol::ResponseKind::StdioSendClose(result) = response else {
-            panic!("stdio send close returned the wrong response");
-        };
-        assert_eq!(
-            crate::Error::from(result.unwrap_err()).kind(),
-            io::ErrorKind::InvalidInput
-        );
-
-        // Stopping drains outstanding endpoints, so release this one first.
-        drop(recv);
-        client.stop().await.unwrap();
-        server.await.unwrap().unwrap();
-    }
-
-    #[cfg(unix)]
-    #[tokio::test]
-    async fn resource_operations_use_the_handle_route() {
-        let temp = tempdir().unwrap();
-        let socket = temp.path().join("inner.sock");
-        let inner_server = Server::bind(&socket).await.unwrap();
-        let inner_task = tokio::spawn(inner_server.accept());
-
-        let (client_stream, server_stream) = tokio::io::duplex(1024 * 1024);
-        let outer_task =
-            tokio::spawn(async move { Server::new(server_stream).await.unwrap().serve().await });
-        let root = Client::new(client_stream).await.unwrap();
-        let path = crate::path::typed_path(socket).unwrap();
-        let selected = root
-            .unix_socket(path.to_path())
-            .await
-            .unwrap()
-            .into_client()
-            .unwrap();
-
-        let (mut send, mut recv) = root.pipe().await.unwrap();
-        send.write_all(b"root").await.unwrap();
-        send.flush().await.unwrap();
-        let mut data = [0; 4];
-        recv.read_exact(&mut data).await.unwrap();
-        assert_eq!(&data, b"root");
-
-        let send_opaque = match &send {
-            crate::StdioSend::Remote(send) => send.stdio.as_ref().unwrap().clone(),
-            crate::StdioSend::Native(_) => panic!("remote pipe returned a native send end"),
-        };
-        let response = selected
-            .request(RequestKind::StdioSendClose {
-                stdio: send_opaque.clone(),
-            })
-            .await
-            .unwrap();
-        let crate::protocol::ResponseKind::StdioSendClose(result) = response else {
-            panic!("stdio close returned the wrong response");
-        };
-        result.unwrap();
-        let mut eof = [0; 1];
-        assert_eq!(recv.read(&mut eof).await.unwrap(), 0);
-
-        let encoded = postcard::to_allocvec(&send_opaque).unwrap();
-        let wrong_vfs: dolang_rpc::session::Opaque<crate::session::VfsMarker> =
-            postcard::from_bytes(&encoded).unwrap();
-        let mut wrong_client = root.clone();
-        wrong_client.vfs = Some(wrong_vfs);
-        assert_eq!(
-            wrong_client
-                .request(RequestKind::Query)
-                .await
-                .unwrap_err()
-                .kind(),
-            io::ErrorKind::InvalidInput
-        );
-
-        selected.stop().await.unwrap();
-        assert_eq!(
-            selected
-                .request(RequestKind::Query)
-                .await
-                .unwrap_err()
-                .kind(),
-            io::ErrorKind::InvalidInput
-        );
-        inner_task.await.unwrap().unwrap();
-        // Stopping drains outstanding endpoints, so release this one first.
-        drop(recv);
-        root.stop().await.unwrap();
-        outer_task.await.unwrap().unwrap();
     }
 
     #[test]

--- a/dolang-vfs/src/client/mod.rs
+++ b/dolang-vfs/src/client/mod.rs
@@ -1724,76 +1724,9 @@ impl AsyncRead for RemoteStdioRecv {
     }
 }
 
-async fn best_effort_close_stdio_send(
-    client: Client,
-    stdio: Opaque<crate::session::StdioSendMarker>,
-) {
-    for _ in 0..4 {
-        let Ok(ResponseKind::StdioSendClose(result)) = client
-            .request(RequestKind::StdioSendClose {
-                stdio: stdio.clone(),
-            })
-            .await
-        else {
-            return;
-        };
-        match result {
-            Ok(()) => return,
-            Err(error)
-                if crate::Error::from(error.clone()).kind() == io::ErrorKind::ResourceBusy =>
-            {
-                tokio::task::yield_now().await;
-            }
-            Err(_) => return,
-        }
-    }
-}
-
-async fn best_effort_close_stdio_recv(
-    client: Client,
-    stdio: Opaque<crate::session::StdioRecvMarker>,
-) {
-    for _ in 0..4 {
-        let Ok(ResponseKind::StdioRecvClose(result)) = client
-            .request(RequestKind::StdioRecvClose {
-                stdio: stdio.clone(),
-            })
-            .await
-        else {
-            return;
-        };
-        match result {
-            Ok(()) => return,
-            Err(error)
-                if crate::Error::from(error.clone()).kind() == io::ErrorKind::ResourceBusy =>
-            {
-                tokio::task::yield_now().await;
-            }
-            Err(_) => return,
-        }
-    }
-}
-
-impl Drop for RemoteStdioSend {
-    fn drop(&mut self) {
-        let Some(stdio) = self.stdio.take() else {
-            return;
-        };
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let client = self.client.clone();
-        runtime.spawn(best_effort_close_stdio_send(client, stdio));
-    }
-}
-
 impl RemoteStdioSend {
     pub(crate) fn client(&self) -> &Client {
         &self.client
-    }
-
-    pub(crate) fn disarm_cleanup(&mut self) {
-        self.stdio.take();
     }
 
     pub(crate) async fn try_clone(&self) -> io::Result<Self> {
@@ -1826,26 +1759,9 @@ impl RemoteStdioSend {
     }
 }
 
-impl Drop for RemoteStdioRecv {
-    fn drop(&mut self) {
-        let Some(stdio) = self.stdio.take() else {
-            return;
-        };
-        let Ok(runtime) = tokio::runtime::Handle::try_current() else {
-            return;
-        };
-        let client = self.client.clone();
-        runtime.spawn(best_effort_close_stdio_recv(client, stdio));
-    }
-}
-
 impl RemoteStdioRecv {
     pub(crate) fn client(&self) -> &Client {
         &self.client
-    }
-
-    pub(crate) fn disarm_cleanup(&mut self) {
-        self.stdio.take();
     }
 
     pub(crate) async fn try_clone(&self) -> io::Result<Self> {
@@ -1915,9 +1831,9 @@ impl<'a> CommandBuilder<'a> {
         client: &Client,
         stdio: ClientRecv,
         relays: &mut PreparedRelays,
-    ) -> crate::Result<(StdioRecvTarget, Option<StdioRecv>)> {
+    ) -> crate::Result<StdioRecvTarget> {
         match stdio {
-            ClientRecv::Null => Ok((StdioRecvTarget::Null, None)),
+            ClientRecv::Null => Ok(StdioRecvTarget::Null),
             ClientRecv::Inherit => {
                 let (send, recv) = client.pipe().await?;
                 relays.stdin = Some(send);
@@ -1933,7 +1849,7 @@ impl<'a> CommandBuilder<'a> {
                 if client.mode() == SessionMode::Remote {
                     return client.unsupported("native process stdio");
                 }
-                Ok((StdioRecvTarget::Native(OsHandle::new(handle)), None))
+                Ok(StdioRecvTarget::Native(OsHandle::new(handle)))
             }
             ClientRecv::Resource(stdio) => match stdio {
                 StdioRecv::Native(_) => {
@@ -1941,7 +1857,7 @@ impl<'a> CommandBuilder<'a> {
                         return client.unsupported("native process stdio");
                     }
                     let handle = stdio.into_blocking_handle().await?;
-                    Ok((StdioRecvTarget::Native(OsHandle::new(handle)), None))
+                    Ok(StdioRecvTarget::Native(OsHandle::new(handle)))
                 }
                 StdioRecv::Remote(remote) => Self::prepare_remote_recv(client, remote),
             },
@@ -1951,7 +1867,7 @@ impl<'a> CommandBuilder<'a> {
     fn prepare_remote_recv(
         client: &Client,
         remote: RemoteStdioRecv,
-    ) -> crate::Result<(StdioRecvTarget, Option<StdioRecv>)> {
+    ) -> crate::Result<StdioRecvTarget> {
         if !client.is_same_vfs(&remote.client) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -1959,18 +1875,18 @@ impl<'a> CommandBuilder<'a> {
             )
             .into());
         }
-        let opaque = remote.stdio.as_ref().unwrap().clone();
-        let stdio = StdioRecv::Remote(remote);
-        Ok((StdioRecvTarget::Opaque(opaque), Some(stdio)))
+        Ok(StdioRecvTarget::Opaque(
+            remote.stdio.as_ref().unwrap().clone(),
+        ))
     }
 
     async fn prepare_send(
         client: &Client,
         stdio: ClientSend,
         relays: &mut PreparedRelays,
-    ) -> crate::Result<(StdioSendTarget, Option<StdioSend>)> {
+    ) -> crate::Result<StdioSendTarget> {
         match stdio {
-            ClientSend::Null => Ok((StdioSendTarget::Null, None)),
+            ClientSend::Null => Ok(StdioSendTarget::Null),
             ClientSend::Inherit(output) => {
                 let (send, recv) = client.pipe().await?;
                 relays.outputs.push((recv, output));
@@ -1986,7 +1902,7 @@ impl<'a> CommandBuilder<'a> {
                 if client.mode() == SessionMode::Remote {
                     return client.unsupported("native process stdio");
                 }
-                Ok((StdioSendTarget::Native(OsHandle::new(handle)), None))
+                Ok(StdioSendTarget::Native(OsHandle::new(handle)))
             }
             ClientSend::Resource(stdio) => match stdio {
                 StdioSend::Native(_) => {
@@ -1994,7 +1910,7 @@ impl<'a> CommandBuilder<'a> {
                         return client.unsupported("native process stdio");
                     }
                     let handle = stdio.into_blocking_handle().await?;
-                    Ok((StdioSendTarget::Native(OsHandle::new(handle)), None))
+                    Ok(StdioSendTarget::Native(OsHandle::new(handle)))
                 }
                 StdioSend::Remote(remote) => Self::prepare_remote_send(client, remote),
             },
@@ -2004,7 +1920,7 @@ impl<'a> CommandBuilder<'a> {
     fn prepare_remote_send(
         client: &Client,
         remote: RemoteStdioSend,
-    ) -> crate::Result<(StdioSendTarget, Option<StdioSend>)> {
+    ) -> crate::Result<StdioSendTarget> {
         if !client.is_same_vfs(&remote.client) {
             return Err(io::Error::new(
                 io::ErrorKind::InvalidInput,
@@ -2012,9 +1928,9 @@ impl<'a> CommandBuilder<'a> {
             )
             .into());
         }
-        let opaque = remote.stdio.as_ref().unwrap().clone();
-        let stdio = StdioSend::Remote(remote);
-        Ok((StdioSendTarget::Opaque(opaque), Some(stdio)))
+        Ok(StdioSendTarget::Opaque(
+            remote.stdio.as_ref().unwrap().clone(),
+        ))
     }
 
     async fn prepare_outputs(
@@ -2022,10 +1938,7 @@ impl<'a> CommandBuilder<'a> {
         stdout: ClientSend,
         stderr: ClientSend,
         relays: &mut PreparedRelays,
-    ) -> crate::Result<(
-        (StdioSendTarget, Option<StdioSend>),
-        (StdioSendTarget, Option<StdioSend>),
-    )> {
+    ) -> crate::Result<(StdioSendTarget, StdioSendTarget)> {
         if client.mode() == SessionMode::Remote
             && matches!(stdout, ClientSend::Inherit(HostOutput::Stdout))
             && matches!(stderr, ClientSend::Inherit(HostOutput::Stdout))
@@ -2317,9 +2230,8 @@ impl<'a> Command for CommandBuilder<'a> {
             termination_policy,
         } = self;
         let mut relays = PreparedRelays::default();
-        let (stdin, mut stdin_resource) = Self::prepare_recv(client, stdin, &mut relays).await?;
-        let ((stdout, mut stdout_resource), (stderr, mut stderr_resource)) =
-            Self::prepare_outputs(client, stdout, stderr, &mut relays).await?;
+        let stdin = Self::prepare_recv(client, stdin, &mut relays).await?;
+        let (stdout, stderr) = Self::prepare_outputs(client, stdout, stderr, &mut relays).await?;
         let req = SpawnRequest {
             program,
             args,
@@ -2332,24 +2244,13 @@ impl<'a> Command for CommandBuilder<'a> {
             termination_policy,
         };
         match client.request(RequestKind::Spawn(req)).await? {
-            ResponseKind::Spawn(result) => {
-                if let Some(stdio) = &mut stdin_resource {
-                    stdio.disarm_remote_cleanup();
-                }
-                if let Some(stdio) = &mut stdout_resource {
-                    stdio.disarm_remote_cleanup();
-                }
-                if let Some(stdio) = &mut stderr_resource {
-                    stdio.disarm_remote_cleanup();
-                }
-                result
-                    .map(|child| ClientChild {
-                        client: client.clone(),
-                        state: ClientChildState::Live(child),
-                        relays: relays.start(),
-                    })
-                    .map_err(Into::into)
-            }
+            ResponseKind::Spawn(result) => result
+                .map(|child| ClientChild {
+                    client: client.clone(),
+                    state: ClientChildState::Live(child),
+                    relays: relays.start(),
+                })
+                .map_err(Into::into),
             response => Err(unexpected(response).into()),
         }
     }

--- a/dolang-vfs/src/directory/mod.rs
+++ b/dolang-vfs/src/directory/mod.rs
@@ -1,6 +1,6 @@
 use std::{collections::VecDeque, io, path::Path};
 
-use dolang_rpc::session::Opaque;
+use dolang_rpc::session::Gift;
 
 use crate::FileType;
 #[cfg(unix)]
@@ -65,7 +65,7 @@ enum ReadDirInner {
 
 struct RemoteReadDir {
     client: crate::Client,
-    handle: Option<Opaque<crate::session::ReadDirMarker>>,
+    handle: Option<Gift<crate::session::ReadDirMarker>>,
     entries: VecDeque<DirEntry>,
 }
 
@@ -106,7 +106,7 @@ impl ReadDir {
 
     pub(crate) fn from_remote(
         client: crate::Client,
-        handle: Opaque<crate::session::ReadDirMarker>,
+        handle: Gift<crate::session::ReadDirMarker>,
     ) -> Self {
         Self {
             inner: ReadDirInner::Remote(RemoteReadDir {
@@ -219,7 +219,7 @@ impl RemoteReadDir {
         if let Some(entry) = self.entries.pop_front() {
             return Ok(Some(entry));
         }
-        let Some(handle) = self.handle.clone() else {
+        let Some(handle) = self.handle.as_ref().map(Gift::cite) else {
             return Ok(None);
         };
         match self
@@ -252,7 +252,9 @@ impl Drop for RemoteReadDir {
         let client = self.client.clone();
         runtime.spawn(async move {
             let _ = client
-                .request(crate::protocol::RequestKind::ReadDirClose { read_dir })
+                .request(crate::protocol::RequestKind::ReadDirClose {
+                    read_dir: read_dir.cite(),
+                })
                 .await;
         });
     }

--- a/dolang-vfs/src/extension.rs
+++ b/dolang-vfs/src/extension.rs
@@ -16,7 +16,7 @@
 //! or remote requests (or both).
 //!
 //! This module is deliberately self-contained: nothing in the public API
-//! (`ExtOpaque`, `ExtGuard`, `ExtResource`, `InvalidHandle`, `ExtOsHandle`,
+//! (`ExtGift`, `ExtCite`, `ExtGuard`, `ExtResource`, `InvalidHandle`, `ExtOsHandle`,
 //! `ExtContext`) names a `dolang_rpc` type. Extension crates should never
 //! need to depend on `dolang-rpc` directly.
 
@@ -31,7 +31,7 @@ use std::{
 use dolang_rpc::{
     handle::DefaultHandle,
     server::CallContext,
-    session::{InvalidOpaque, Opaque, OpaqueGuard, OpaqueResource},
+    session::{Cite, Gift, InvalidOpaque, OpaqueGuard, OpaqueResource},
 };
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -356,22 +356,34 @@ impl<'a> ExtContext<'a> {
     /// Registers a value in the session's opaque-object table, returning a
     /// handle that can cross the wire (when remote) and be redeemed with
     /// [`acquire`](Self::acquire)/[`unregister`](Self::unregister).
-    pub fn register<T: ExtResource>(&self, value: T) -> ExtOpaque<T::Marker> {
+    ///
+    /// The result is an [`ExtGift`], which belongs in a wire position that
+    /// hands the peer a reference. The peer names it back with
+    /// [`ExtGift::cite`], and only the resulting [`ExtCite`] can be acquired.
+    ///
+    /// # Panics
+    ///
+    /// In remote mode, if a different concrete type has already been
+    /// registered under `T::Marker` on this session: a marker must name
+    /// exactly one resource type, since it is the only type information that
+    /// crosses the wire.
+    pub fn register<T: ExtResource>(&self, value: T) -> ExtGift<T::Marker> {
         match &self.inner {
-            Inner::Direct(_) => ExtOpaque(OpaqueRepr::Direct(Arc::new(value))),
+            Inner::Direct(_) => ExtGift(GiftRepr::Direct(Arc::new(value))),
             Inner::Remote { context, .. } => {
-                ExtOpaque(OpaqueRepr::Remote(context.register(Wrap(value))))
+                ExtGift(GiftRepr::Remote(context.register(Wrap(value))))
             }
         }
     }
 
-    /// Resolves a handle previously returned by [`register`](Self::register).
+    /// Resolves a citation of a handle previously returned by
+    /// [`register`](Self::register).
     pub fn acquire<T: ExtResource>(
         &self,
-        handle: ExtOpaque<T::Marker>,
+        handle: ExtCite<T::Marker>,
     ) -> Result<ExtGuard<T>, InvalidHandle> {
         match (&self.inner, handle.0) {
-            (Inner::Direct(_), OpaqueRepr::Direct(value)) => {
+            (Inner::Direct(_), CiteRepr::Direct(value)) => {
                 if (*value).type_id() != TypeId::of::<T>() {
                     return Err(InvalidHandle);
                 }
@@ -379,8 +391,8 @@ impl<'a> ExtContext<'a> {
                     value.downcast::<T>().map_err(|_| InvalidHandle)?,
                 )))
             }
-            (Inner::Remote { context, .. }, OpaqueRepr::Remote(opaque)) => Ok(ExtGuard(
-                GuardRepr::Remote(context.acquire::<Wrap<T>>(opaque)?),
+            (Inner::Remote { context, .. }, CiteRepr::Remote(cite)) => Ok(ExtGuard(
+                GuardRepr::Remote(context.acquire::<Wrap<T>>(cite)?),
             )),
             _ => Err(InvalidHandle),
         }
@@ -390,18 +402,18 @@ impl<'a> ExtContext<'a> {
     /// returning the stored value if this was the last reference to it.
     pub fn unregister<T: ExtResource>(
         &self,
-        handle: ExtOpaque<T::Marker>,
+        handle: ExtCite<T::Marker>,
     ) -> Result<Option<T>, InvalidHandle> {
         match (&self.inner, handle.0) {
-            (Inner::Direct(_), OpaqueRepr::Direct(value)) => {
+            (Inner::Direct(_), CiteRepr::Direct(value)) => {
                 if (*value).type_id() != TypeId::of::<T>() {
                     return Err(InvalidHandle);
                 }
                 let value = value.downcast::<T>().map_err(|_| InvalidHandle)?;
                 Ok(Arc::try_unwrap(value).ok())
             }
-            (Inner::Remote { context, .. }, OpaqueRepr::Remote(opaque)) => {
-                Ok(context.unregister::<Wrap<T>>(opaque)?.map(|w| w.0))
+            (Inner::Remote { context, .. }, CiteRepr::Remote(cite)) => {
+                Ok(context.unregister::<Wrap<T>>(cite)?.map(|w| w.0))
             }
             _ => Err(InvalidHandle),
         }
@@ -416,7 +428,9 @@ impl<'a> ExtContext<'a> {
 /// would leak its `Marker`-keyed object-table design into every extension
 /// crate's own trait-impl list.
 pub trait ExtResource: Send + Sync + 'static {
-    type Marker: ?Sized + 'static;
+    /// A trivial type naming this resource on the wire. It must name only
+    /// this one — see [`ExtContext::register`].
+    type Marker: 'static;
 }
 
 /// Private adapter bridging [`ExtResource`] to `dolang_rpc::session::OpaqueResource`
@@ -427,51 +441,98 @@ impl<T: ExtResource> OpaqueResource for Wrap<T> {
     type Marker = T::Marker;
 }
 
-/// A handle to a value registered via [`ExtContext::register`].
+/// A handle to a value registered via [`ExtContext::register`], in a wire
+/// position that grants the peer a reference to it.
 ///
 /// Uses a distinct `Marker` type parameter rather than the concrete stored
 /// type so the handle a caller holds does not need to name (or even know)
 /// the private type actually retained behind it — the same design
-/// `dolang_rpc::session::Opaque` uses for its own object table.
+/// `dolang_rpc::session::Gift` uses for its own object table.
 ///
 /// Opaque by design: the direct/remote split is an implementation detail,
 /// not something extension authors match on.
-pub struct ExtOpaque<M: ?Sized + 'static>(OpaqueRepr<M>);
+pub struct ExtGift<M: 'static>(GiftRepr<M>);
 
-enum OpaqueRepr<M: ?Sized + 'static> {
+/// The same handle in a wire position that names a reference the receiver has
+/// already granted, produced by [`ExtGift::cite`].
+///
+/// Which of the two a protocol field holds is fixed by the protocol, so it is
+/// spelled in the field's type and checked when the field is decoded. See
+/// `dolang_rpc::session` for what the distinction buys.
+pub struct ExtCite<M: 'static>(CiteRepr<M>);
+
+enum GiftRepr<M: 'static> {
     Direct(Arc<dyn Any + Send + Sync>),
-    Remote(Opaque<M>),
+    Remote(Gift<M>),
 }
 
-impl<M: ?Sized> Clone for ExtOpaque<M> {
-    fn clone(&self) -> Self {
+enum CiteRepr<M: 'static> {
+    Direct(Arc<dyn Any + Send + Sync>),
+    Remote(Cite<M>),
+}
+
+impl<M> ExtGift<M> {
+    /// Names this resource back to the endpoint that owns it, for a wire
+    /// position that must not transfer a reference.
+    ///
+    /// # Panics
+    ///
+    /// In remote mode, if this endpoint is itself the owner — see
+    /// `dolang_rpc::session::Gift::cite`. Direct mode has no wire and no
+    /// owner, so it cannot fail this way; extensions should still route
+    /// through here so that the two modes agree.
+    pub fn cite(&self) -> ExtCite<M> {
         match &self.0 {
-            OpaqueRepr::Direct(value) => Self(OpaqueRepr::Direct(value.clone())),
-            OpaqueRepr::Remote(opaque) => Self(OpaqueRepr::Remote(opaque.clone())),
+            GiftRepr::Direct(value) => ExtCite(CiteRepr::Direct(value.clone())),
+            GiftRepr::Remote(gift) => ExtCite(CiteRepr::Remote(gift.cite())),
         }
     }
 }
 
-impl<M: ?Sized + 'static> Serialize for ExtOpaque<M> {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        match &self.0 {
-            OpaqueRepr::Remote(opaque) => opaque.serialize(serializer),
-            OpaqueRepr::Direct(_) => Err(serde::ser::Error::custom(
-                "cannot serialize a direct-mode extension handle",
-            )),
+/// Both handles are the same value in different wire positions, so everything
+/// that does not touch the wire is identical between them.
+macro_rules! ext_handle {
+    ($name:ident, $repr:ident) => {
+        impl<M> Clone for $name<M> {
+            fn clone(&self) -> Self {
+                match &self.0 {
+                    $repr::Direct(value) => Self($repr::Direct(value.clone())),
+                    $repr::Remote(handle) => Self($repr::Remote(handle.clone())),
+                }
+            }
         }
-    }
+
+        impl<M: 'static> Serialize for $name<M> {
+            fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                match &self.0 {
+                    $repr::Remote(handle) => handle.serialize(serializer),
+                    $repr::Direct(_) => Err(serde::ser::Error::custom(
+                        "cannot serialize a direct-mode extension handle",
+                    )),
+                }
+            }
+        }
+    };
 }
 
-impl<'de, M: ?Sized + 'static> Deserialize<'de> for ExtOpaque<M> {
+ext_handle!(ExtGift, GiftRepr);
+ext_handle!(ExtCite, CiteRepr);
+
+impl<'de, M: 'static> Deserialize<'de> for ExtGift<M> {
     fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        Opaque::<M>::deserialize(deserializer).map(|opaque| Self(OpaqueRepr::Remote(opaque)))
+        Gift::<M>::deserialize(deserializer).map(|gift| Self(GiftRepr::Remote(gift)))
+    }
+}
+
+impl<'de, M: 'static> Deserialize<'de> for ExtCite<M> {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        Cite::<M>::deserialize(deserializer).map(|cite| Self(CiteRepr::Remote(cite)))
     }
 }
 
 /// A retained, typed handle acquired via [`ExtContext::acquire`].
 ///
-/// Opaque by design, for the same reason as [`ExtOpaque`].
+/// Opaque by design, for the same reason as [`ExtGift`].
 pub struct ExtGuard<T>(GuardRepr<T>);
 
 enum GuardRepr<T> {
@@ -489,7 +550,7 @@ impl<T> std::ops::Deref for ExtGuard<T> {
     }
 }
 
-/// Error returned when an [`ExtOpaque`]/handle does not refer to a live,
+/// Error returned when an [`ExtGift`]/[`ExtCite`] does not refer to a live,
 /// correctly-typed value.
 #[derive(Clone, Copy, Debug, thiserror::Error)]
 #[error("invalid extension handle")]

--- a/dolang-vfs/src/process/mod.rs
+++ b/dolang-vfs/src/process/mod.rs
@@ -316,11 +316,6 @@ fn create_pipe_sized(size: usize) -> io::Result<(std::io::PipeReader, std::io::P
 }
 
 impl StdioSend {
-    pub(crate) fn disarm_remote_cleanup(&mut self) {
-        if let Self::Remote(remote) = self {
-            remote.disarm_cleanup();
-        }
-    }
     pub(crate) fn from_file(file: File) -> Self {
         Self::Native(NativeStdioSend::File(file))
     }
@@ -398,11 +393,6 @@ impl StdioSend {
 }
 
 impl StdioRecv {
-    pub(crate) fn disarm_remote_cleanup(&mut self) {
-        if let Self::Remote(remote) = self {
-            remote.disarm_cleanup();
-        }
-    }
     pub(crate) fn from_file(file: File) -> Self {
         Self::Native(NativeStdioRecv::File(file))
     }

--- a/dolang-vfs/src/protocol.rs
+++ b/dolang-vfs/src/protocol.rs
@@ -2,7 +2,11 @@ use std::any::Any;
 use std::collections::HashMap;
 use std::{io, path::PathBuf};
 
-use dolang_rpc::{Protocol, handle::OsHandle, session::Opaque};
+use dolang_rpc::{
+    Protocol,
+    handle::OsHandle,
+    session::{Cite, Gift},
+};
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{Error as _, SeqAccess, Visitor},
@@ -53,7 +57,7 @@ pub(crate) fn rpc_builder() -> dolang_rpc::Builder {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct Request {
-    pub(crate) vfs: Option<Opaque<crate::session::VfsMarker>>,
+    pub(crate) vfs: Option<Cite<crate::session::VfsMarker>>,
     pub(crate) kind: RequestKind,
 }
 
@@ -270,22 +274,22 @@ pub(crate) struct SpawnRequest {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) struct PipeResponse {
-    pub(crate) send: Opaque<crate::session::StdioSendMarker>,
-    pub(crate) recv: Opaque<crate::session::StdioRecvMarker>,
+    pub(crate) send: Gift<crate::session::StdioSendMarker>,
+    pub(crate) recv: Gift<crate::session::StdioRecvMarker>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum StdioRecvTarget {
     Null,
     Native(OsHandle),
-    Opaque(Opaque<crate::session::StdioRecvMarker>),
+    Opaque(Cite<crate::session::StdioRecvMarker>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum StdioSendTarget {
     Null,
     Native(OsHandle),
-    Opaque(Opaque<crate::session::StdioSendMarker>),
+    Opaque(Cite<crate::session::StdioSendMarker>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -316,7 +320,7 @@ pub(crate) enum OpenHandlePreference {
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum OpenHandle {
     Native(OsHandle),
-    Opaque(Opaque<crate::session::FileMarker>),
+    Opaque(Gift<crate::session::FileMarker>),
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy)]
@@ -361,7 +365,7 @@ pub(crate) struct WindowsAdminRequest {
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum OpenVfsHandle {
     Native(OsHandle),
-    Opaque(Opaque<crate::session::VfsMarker>),
+    Opaque(Gift<crate::session::VfsMarker>),
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -697,13 +701,13 @@ impl<'de> Deserialize<'de> for ExtensionResponse {
 pub(crate) enum RequestKind {
     Spawn(SpawnRequest),
     ChildWait {
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     },
     ChildTerminate {
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     },
     ChildClose {
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     },
     Query,
     UserName {
@@ -735,104 +739,104 @@ pub(crate) enum RequestKind {
     Pipe,
     Open(OpenRequest),
     FileRead {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         len: usize,
     },
     FileWrite {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     FileSeek {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         position: FileSeekFrom,
     },
     FileFlush {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     FileSetSize {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         size: u64,
     },
     FileLock {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         request: crate::file::FileLockRequest,
     },
     FileUnlock {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         lock: u64,
     },
     FileToStdioSend {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     FileToStdioRecv {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     StdioSendClose {
-        stdio: Opaque<crate::session::StdioSendMarker>,
+        stdio: Cite<crate::session::StdioSendMarker>,
     },
     StdioSendWrite {
-        stdio: Opaque<crate::session::StdioSendMarker>,
+        stdio: Cite<crate::session::StdioSendMarker>,
     },
     StdioSendClone {
-        stdio: Opaque<crate::session::StdioSendMarker>,
+        stdio: Cite<crate::session::StdioSendMarker>,
     },
     StdioRecvClose {
-        stdio: Opaque<crate::session::StdioRecvMarker>,
+        stdio: Cite<crate::session::StdioRecvMarker>,
     },
     StdioRecvRead {
-        stdio: Opaque<crate::session::StdioRecvMarker>,
+        stdio: Cite<crate::session::StdioRecvMarker>,
         len: usize,
     },
     StdioRecvClone {
-        stdio: Opaque<crate::session::StdioRecvMarker>,
+        stdio: Cite<crate::session::StdioRecvMarker>,
     },
     FileMetadata {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     FileFsMetadata {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     FileAcl {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         default: bool,
     },
     FileSetAcl {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         acl: Option<PosixAcl>,
         default: bool,
     },
     FileSecDesc {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         mask: u32,
     },
     FileSetSecDesc {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         sec_desc: SecDesc,
     },
     FileXattrs {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         namespace: XattrNamespaceRequest,
     },
     FileXattr {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         name: String,
         namespace: Option<String>,
     },
     FileStreams {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     FileSetXattr {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         name: String,
         namespace: Option<String>,
         value: Vec<u8>,
     },
     FileRemoveXattr {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
         name: String,
         namespace: Option<String>,
     },
     FileClose {
-        file: Opaque<crate::session::FileMarker>,
+        file: Cite<crate::session::FileMarker>,
     },
     UnixVfs(UnixVfsRequest),
     WindowsAdmin(WindowsAdminRequest),
@@ -840,10 +844,10 @@ pub(crate) enum RequestKind {
         path: WirePath,
     },
     ReadDirNext {
-        read_dir: Opaque<crate::session::ReadDirMarker>,
+        read_dir: Cite<crate::session::ReadDirMarker>,
     },
     ReadDirClose {
-        read_dir: Opaque<crate::session::ReadDirMarker>,
+        read_dir: Cite<crate::session::ReadDirMarker>,
     },
     Remove(RemoveRequest),
     Metadata(MetadataRequest),
@@ -876,7 +880,7 @@ pub(crate) enum RequestKind {
 #[derive(Serialize, Deserialize, Debug)]
 pub(crate) enum ResponseKind {
     Error(WireError),
-    Spawn(Result<Opaque<crate::session::ChildMarker>, WireError>),
+    Spawn(Result<Gift<crate::session::ChildMarker>, WireError>),
     ChildWait(Result<crate::ProcessStatus, WireError>),
     ChildTerminate(Result<Option<crate::ProcessStatus>, WireError>),
     ChildClose(Result<(), WireError>),
@@ -900,14 +904,14 @@ pub(crate) enum ResponseKind {
     FileSetSize(Result<(), WireError>),
     FileLock(Result<Option<u64>, WireError>),
     FileUnlock(Result<(), WireError>),
-    FileToStdioSend(Result<Opaque<crate::session::StdioSendMarker>, WireError>),
-    FileToStdioRecv(Result<Opaque<crate::session::StdioRecvMarker>, WireError>),
+    FileToStdioSend(Result<Gift<crate::session::StdioSendMarker>, WireError>),
+    FileToStdioRecv(Result<Gift<crate::session::StdioRecvMarker>, WireError>),
     StdioSendClose(Result<(), WireError>),
     StdioSendWrite(Result<usize, WireError>),
-    StdioSendClone(Result<Opaque<crate::session::StdioSendMarker>, WireError>),
+    StdioSendClone(Result<Gift<crate::session::StdioSendMarker>, WireError>),
     StdioRecvClose(Result<(), WireError>),
     StdioRecvRead(Result<(), WireError>),
-    StdioRecvClone(Result<Opaque<crate::session::StdioRecvMarker>, WireError>),
+    StdioRecvClone(Result<Gift<crate::session::StdioRecvMarker>, WireError>),
     FileMetadata(Result<Metadata, WireError>),
     FileFsMetadata(Result<FsMetadata, WireError>),
     FileAcl(Result<Option<PosixAcl>, WireError>),
@@ -921,8 +925,8 @@ pub(crate) enum ResponseKind {
     FileRemoveXattr(Result<(), WireError>),
     FileClose(Result<(), WireError>),
     UnixVfs(Result<OpenVfsHandle, WireError>),
-    WindowsAdmin(Result<Opaque<crate::session::VfsMarker>, WireError>),
-    ReadDir(Result<Opaque<crate::session::ReadDirMarker>, WireError>),
+    WindowsAdmin(Result<Gift<crate::session::VfsMarker>, WireError>),
+    ReadDir(Result<Gift<crate::session::ReadDirMarker>, WireError>),
     ReadDirNext(Result<ReadDirPage, WireError>),
     ReadDirClose(Result<(), WireError>),
     Remove(Result<(), WireError>),

--- a/dolang-vfs/src/server/mod.rs
+++ b/dolang-vfs/src/server/mod.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use dolang_rpc::{
     handle::{DefaultHandle, OsHandle},
     server::CallContext,
-    session::{Opaque, OpaqueGuard, OpaqueResource},
+    session::{Cite, OpaqueGuard, OpaqueResource},
 };
 use dolang_winterop::security::SecDesc;
 #[cfg(unix)]
@@ -451,7 +451,7 @@ impl Connection {
     fn select(
         &self,
         context: &CallContext<VfsProtocol>,
-        vfs: Option<Opaque<crate::session::VfsMarker>>,
+        vfs: Option<Cite<crate::session::VfsMarker>>,
     ) -> Result<Self, WireError> {
         let Some(vfs) = vfs else {
             return Ok(self.clone());
@@ -473,7 +473,7 @@ impl Connection {
     async fn handle_stop(
         &self,
         context: &mut CallContext<VfsProtocol>,
-        vfs: Option<Opaque<crate::session::VfsMarker>>,
+        vfs: Option<Cite<crate::session::VfsMarker>>,
         stop: &AtomicBool,
     ) -> ResponseKind {
         let Some(vfs) = vfs else {
@@ -890,7 +890,7 @@ impl Connection {
     fn take_child(
         &self,
         context: &CallContext<VfsProtocol>,
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     ) -> Result<RetainedChild, WireError> {
         context
             .unregister::<RetainedChild>(child)
@@ -911,7 +911,7 @@ impl Connection {
     async fn handle_child_wait(
         &self,
         context: &mut CallContext<VfsProtocol>,
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     ) -> ResponseKind {
         let result = match self.take_child(context, child) {
             Ok(child) => {
@@ -934,7 +934,7 @@ impl Connection {
     async fn handle_child_terminate(
         &self,
         context: &CallContext<VfsProtocol>,
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     ) -> ResponseKind {
         let result = match self.take_child(context, child) {
             Ok(child) => child.0.into_inner().terminate().await.map_err(wire_error),
@@ -946,7 +946,7 @@ impl Connection {
     fn handle_child_close(
         &self,
         context: &CallContext<VfsProtocol>,
-        child: Opaque<crate::session::ChildMarker>,
+        child: Cite<crate::session::ChildMarker>,
     ) -> ResponseKind {
         let result = context
             .unregister::<RetainedChild>(child)
@@ -1012,7 +1012,7 @@ impl Connection {
     fn retained_stdio_send(
         &self,
         context: &CallContext<VfsProtocol>,
-        stdio: Opaque<StdioSendMarker>,
+        stdio: Cite<StdioSendMarker>,
     ) -> Result<OpaqueGuard<RetainedStdioSend>, WireError> {
         context
             .acquire::<RetainedStdioSend>(stdio)
@@ -1022,7 +1022,7 @@ impl Connection {
     fn retained_stdio_recv(
         &self,
         context: &CallContext<VfsProtocol>,
-        stdio: Opaque<StdioRecvMarker>,
+        stdio: Cite<StdioRecvMarker>,
     ) -> Result<OpaqueGuard<RetainedStdioRecv>, WireError> {
         context
             .acquire::<RetainedStdioRecv>(stdio)
@@ -1041,7 +1041,7 @@ impl Connection {
     fn close_stdio_send(
         &self,
         context: &CallContext<VfsProtocol>,
-        stdio: Opaque<StdioSendMarker>,
+        stdio: Cite<StdioSendMarker>,
     ) -> Result<(), WireError> {
         context
             .unregister::<RetainedStdioSend>(stdio)
@@ -1052,7 +1052,7 @@ impl Connection {
     fn close_stdio_recv(
         &self,
         context: &CallContext<VfsProtocol>,
-        stdio: Opaque<StdioRecvMarker>,
+        stdio: Cite<StdioRecvMarker>,
     ) -> Result<(), WireError> {
         context
             .unregister::<RetainedStdioRecv>(stdio)
@@ -1063,7 +1063,7 @@ impl Connection {
     async fn handle_stdio_send_write(
         &self,
         context: &mut CallContext<VfsProtocol>,
-        stdio: Opaque<StdioSendMarker>,
+        stdio: Cite<StdioSendMarker>,
     ) -> ResponseKind {
         let result = async {
             let stdio = self.retained_stdio_send(context, stdio)?;
@@ -1090,7 +1090,7 @@ impl Connection {
     async fn handle_stdio_send_clone(
         &self,
         context: &CallContext<VfsProtocol>,
-        stdio: Opaque<StdioSendMarker>,
+        stdio: Cite<StdioSendMarker>,
     ) -> ResponseKind {
         let result = async {
             let stdio = self.retained_stdio_send(context, stdio)?;
@@ -1114,7 +1114,7 @@ impl Connection {
     async fn handle_stdio_recv_read(
         &self,
         context: CallContext<VfsProtocol>,
-        stdio: Opaque<StdioRecvMarker>,
+        stdio: Cite<StdioRecvMarker>,
         len: usize,
     ) {
         let stdio = match self.retained_stdio_recv(&context, stdio) {
@@ -1135,7 +1135,7 @@ impl Connection {
     async fn handle_stdio_recv_clone(
         &self,
         context: &CallContext<VfsProtocol>,
-        stdio: Opaque<StdioRecvMarker>,
+        stdio: Cite<StdioRecvMarker>,
     ) -> ResponseKind {
         let result = async {
             let stdio = self.retained_stdio_recv(context, stdio)?;
@@ -1193,7 +1193,7 @@ impl Connection {
     fn retained_file(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> Result<OpaqueGuard<RetainedFile>, WireError> {
         context.acquire::<RetainedFile>(file).map_err(|_| {
             wire_error(io::Error::new(
@@ -1206,7 +1206,7 @@ impl Connection {
     async fn handle_file_read(
         &self,
         context: CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         len: usize,
     ) {
         let file = match self.retained_file(&context, file) {
@@ -1227,7 +1227,7 @@ impl Connection {
     async fn handle_file_write(
         &self,
         context: &mut CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1254,7 +1254,7 @@ impl Connection {
     async fn handle_file_seek(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         position: io::SeekFrom,
     ) -> ResponseKind {
         let result = async {
@@ -1268,7 +1268,7 @@ impl Connection {
     async fn handle_file_flush(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1281,7 +1281,7 @@ impl Connection {
     async fn handle_file_set_size(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         size: u64,
     ) -> ResponseKind {
         let result = async {
@@ -1295,7 +1295,7 @@ impl Connection {
     async fn handle_file_to_stdio_send(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1319,7 +1319,7 @@ impl Connection {
     async fn handle_file_to_stdio_recv(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1343,7 +1343,7 @@ impl Connection {
     async fn handle_file_metadata(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1356,7 +1356,7 @@ impl Connection {
     async fn handle_file_fs_metadata(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1369,7 +1369,7 @@ impl Connection {
     async fn handle_file_sec_desc(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         mask: u32,
     ) -> ResponseKind {
         let result = async {
@@ -1383,7 +1383,7 @@ impl Connection {
     async fn handle_file_acl(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         default: bool,
     ) -> ResponseKind {
         let result = async {
@@ -1397,7 +1397,7 @@ impl Connection {
     async fn handle_file_set_acl(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         acl: Option<PosixAcl>,
         default: bool,
     ) -> ResponseKind {
@@ -1417,7 +1417,7 @@ impl Connection {
     async fn handle_file_set_sec_desc(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         sec_desc: SecDesc,
     ) -> ResponseKind {
         let result = async {
@@ -1436,7 +1436,7 @@ impl Connection {
     async fn handle_file_xattrs(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         namespace: XattrNamespaceRequest,
     ) -> ResponseKind {
         let result = async {
@@ -1455,7 +1455,7 @@ impl Connection {
     async fn handle_file_xattr(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         name: String,
         namespace: Option<String>,
     ) -> ResponseKind {
@@ -1475,7 +1475,7 @@ impl Connection {
     async fn handle_file_streams(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let result = async {
             let file = self.retained_file(context, file)?;
@@ -1488,7 +1488,7 @@ impl Connection {
     async fn handle_file_set_xattr(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         name: String,
         namespace: Option<String>,
         value: Vec<u8>,
@@ -1509,7 +1509,7 @@ impl Connection {
     async fn handle_file_remove_xattr(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         name: String,
         namespace: Option<String>,
     ) -> ResponseKind {
@@ -1529,7 +1529,7 @@ impl Connection {
     async fn handle_file_lock(
         &self,
         context: &mut CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         request: FileLockRequest,
     ) -> ResponseKind {
         let retained = match self.retained_file(context, file) {
@@ -1566,7 +1566,7 @@ impl Connection {
     async fn handle_file_unlock(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
         lock: u64,
     ) -> ResponseKind {
         let retained = match self.retained_file(context, file) {
@@ -1592,7 +1592,7 @@ impl Connection {
     async fn handle_file_close(
         &self,
         context: &CallContext<VfsProtocol>,
-        file: Opaque<FileMarker>,
+        file: Cite<FileMarker>,
     ) -> ResponseKind {
         let retained = match self.retained_file(context, file.clone()) {
             Ok(retained) => retained,
@@ -1644,7 +1644,7 @@ impl Connection {
     async fn handle_read_dir_next(
         &self,
         context: &CallContext<VfsProtocol>,
-        read_dir: Opaque<crate::session::ReadDirMarker>,
+        read_dir: Cite<crate::session::ReadDirMarker>,
     ) -> ResponseKind {
         let result: crate::Result<ReadDirPage> = async {
             let retained = context
@@ -1678,7 +1678,7 @@ impl Connection {
     fn handle_read_dir_close(
         &self,
         context: &CallContext<VfsProtocol>,
-        read_dir: Opaque<crate::session::ReadDirMarker>,
+        read_dir: Cite<crate::session::ReadDirMarker>,
     ) -> ResponseKind {
         let result = context
             .unregister::<RetainedReadDir>(read_dir)
@@ -2111,7 +2111,7 @@ mod tests {
             panic!("remote open did not return an opaque file");
         };
         let ResponseKind::FileClose(result) = client
-            .call(request(RequestKind::FileClose { file: file.clone() }))
+            .call(request(RequestKind::FileClose { file: file.cite() }))
             .await
             .unwrap()
             .into_response()
@@ -2120,7 +2120,7 @@ mod tests {
         };
         result.unwrap();
         let ResponseKind::FileClose(result) = client
-            .call(request(RequestKind::FileClose { file }))
+            .call(request(RequestKind::FileClose { file: file.cite() }))
             .await
             .unwrap()
             .into_response()

--- a/dolang-vfs/src/server/mod.rs
+++ b/dolang-vfs/src/server/mod.rs
@@ -119,6 +119,20 @@ impl Drain {
     }
 }
 
+/// A reserved drain slot, returned when the endpoint holding it dies.
+///
+/// Accounting rides the endpoint's own lifetime rather than any particular
+/// message, so an endpoint reaches the drain exactly once however it ends:
+/// explicitly closed, consumed by a spawn, or released because the peer
+/// dropped the last opaque naming it.
+struct DrainSlot(Arc<Drain>);
+
+impl Drop for DrainSlot {
+    fn drop(&mut self) {
+        self.0.release(1);
+    }
+}
+
 struct RetainedVfs {
     vfs: AnyVfs,
     session: Option<crate::session::VfsSession>,
@@ -157,13 +171,21 @@ impl OpaqueResource for RetainedFile {
     type Marker = FileMarker;
 }
 
-struct RetainedStdioSend(Mutex<StdioSend>);
+struct RetainedStdioSend {
+    stdio: Mutex<StdioSend>,
+    /// Returned to the drain when the endpoint dies, however it ends.
+    _slot: DrainSlot,
+}
 
 impl OpaqueResource for RetainedStdioSend {
     type Marker = StdioSendMarker;
 }
 
-struct RetainedStdioRecv(Mutex<StdioRecv>);
+struct RetainedStdioRecv {
+    stdio: Mutex<StdioRecv>,
+    /// Returned to the drain when the endpoint dies, however it ends.
+    _slot: DrainSlot,
+}
 
 impl OpaqueResource for RetainedStdioRecv {
     type Marker = StdioRecvMarker;
@@ -782,17 +804,20 @@ impl Connection {
                 ))))
             }
             StdioRecvTarget::Opaque(stdio) => {
+                // Consuming the endpoint hands it to the child, which takes
+                // its drain slot along with it: once a child owns an endpoint
+                // the peer is no longer relaying through it, which is the only
+                // thing the drain protects.
                 let stdio = context
                     .unregister::<RetainedStdioRecv>(stdio)
                     .map_err(|_| Self::invalid_opaque("stdio receive"))?;
-                self.drain.release(1);
                 let Some(stdio) = stdio else {
                     return Err(wire_error(io::Error::new(
                         io::ErrorKind::ResourceBusy,
                         "opaque stdio receive is in use",
                     )));
                 };
-                Ok(Some(stdio.0.into_inner()))
+                Ok(Some(stdio.stdio.into_inner()))
             }
         }
     }
@@ -813,17 +838,20 @@ impl Connection {
                 ))))
             }
             StdioSendTarget::Opaque(stdio) => {
+                // Consuming the endpoint hands it to the child, which takes
+                // its drain slot along with it: once a child owns an endpoint
+                // the peer is no longer relaying through it, which is the only
+                // thing the drain protects.
                 let stdio = context
                     .unregister::<RetainedStdioSend>(stdio)
                     .map_err(|_| Self::invalid_opaque("stdio send"))?;
-                self.drain.release(1);
                 let Some(stdio) = stdio else {
                     return Err(wire_error(io::Error::new(
                         io::ErrorKind::ResourceBusy,
                         "opaque stdio send is in use",
                     )));
                 };
-                Ok(Some(stdio.0.into_inner()))
+                Ok(Some(stdio.stdio.into_inner()))
             }
         }
     }
@@ -950,9 +978,9 @@ impl Connection {
     /// available while stopping: they create no stdio endpoint of their own,
     /// and refusing a spawn could break the very in-flight pipeline stage the
     /// drain exists to protect.
-    fn reserve_stdio(&self, count: usize) -> Result<(), WireError> {
-        if self.drain.try_acquire(count) {
-            Ok(())
+    fn reserve_stdio(&self) -> Result<DrainSlot, WireError> {
+        if self.drain.try_acquire(1) {
+            Ok(DrainSlot(self.drain.clone()))
         } else {
             Err(wire_error(io::Error::new(
                 io::ErrorKind::NotConnected,
@@ -964,10 +992,17 @@ impl Connection {
     async fn handle_pipe(&self, context: &CallContext<VfsProtocol>) -> ResponseKind {
         let result = async {
             let (send, recv) = self.server.vfs.pipe().await.map_err(wire_error)?;
-            self.reserve_stdio(2)?;
+            let send_slot = self.reserve_stdio()?;
+            let recv_slot = self.reserve_stdio()?;
             Ok(PipeResponse {
-                send: context.register(RetainedStdioSend(Mutex::new(send))),
-                recv: context.register(RetainedStdioRecv(Mutex::new(recv))),
+                send: context.register(RetainedStdioSend {
+                    stdio: Mutex::new(send),
+                    _slot: send_slot,
+                }),
+                recv: context.register(RetainedStdioRecv {
+                    stdio: Mutex::new(recv),
+                    _slot: recv_slot,
+                }),
             })
         }
         .await;
@@ -994,28 +1029,24 @@ impl Connection {
             .map_err(|_| Self::invalid_opaque("stdio receive"))
     }
 
+    /// Empties an endpoint's contents, without waiting for the peer to stop
+    /// naming it.
+    ///
+    /// A close that races the endpoint's own read or write leaves the contents
+    /// alive until that operation finishes, and the registration alive until
+    /// the peer drops its last reference. Neither is worth reporting: a peer
+    /// closing while its own I/O is in flight has no flush guarantee to lose,
+    /// and the drain slot is returned when the endpoint actually dies rather
+    /// than when this request happens to be served.
     fn close_stdio_send(
         &self,
         context: &CallContext<VfsProtocol>,
         stdio: Opaque<StdioSendMarker>,
     ) -> Result<(), WireError> {
-        let retained = self.retained_stdio_send(context, stdio.clone())?;
-        drop(retained);
-        let retained = context
+        context
             .unregister::<RetainedStdioSend>(stdio)
             .map_err(|_| Self::invalid_opaque("stdio send"))?;
-        // The endpoint is out of the object table either way, so it no longer
-        // holds up a drain. A racing read or write can still be holding the
-        // last reference, but a peer doing that while closing has no flush
-        // guarantee to lose.
-        self.drain.release(1);
-        match retained {
-            Some(_) => Ok(()),
-            None => Err(wire_error(io::Error::new(
-                io::ErrorKind::ResourceBusy,
-                "opaque stdio send is in use",
-            ))),
-        }
+        Ok(())
     }
 
     fn close_stdio_recv(
@@ -1023,23 +1054,10 @@ impl Connection {
         context: &CallContext<VfsProtocol>,
         stdio: Opaque<StdioRecvMarker>,
     ) -> Result<(), WireError> {
-        let retained = self.retained_stdio_recv(context, stdio.clone())?;
-        drop(retained);
-        let retained = context
+        context
             .unregister::<RetainedStdioRecv>(stdio)
             .map_err(|_| Self::invalid_opaque("stdio receive"))?;
-        // The endpoint is out of the object table either way, so it no longer
-        // holds up a drain. A racing read or write can still be holding the
-        // last reference, but a peer doing that while closing has no flush
-        // guarantee to lose.
-        self.drain.release(1);
-        match retained {
-            Some(_) => Ok(()),
-            None => Err(wire_error(io::Error::new(
-                io::ErrorKind::ResourceBusy,
-                "opaque stdio receive is in use",
-            ))),
-        }
+        Ok(())
     }
 
     async fn handle_stdio_send_write(
@@ -1055,7 +1073,7 @@ impl Connection {
                     "stdio write request is missing its data trailer",
                 ))
             })?;
-            let len = io::copy(trailer, &mut *stdio.0.lock().await)
+            let len = io::copy(trailer, &mut *stdio.stdio.lock().await)
                 .await
                 .map_err(wire_error)?;
             usize::try_from(len).map_err(|_| {
@@ -1076,9 +1094,18 @@ impl Connection {
     ) -> ResponseKind {
         let result = async {
             let stdio = self.retained_stdio_send(context, stdio)?;
-            let clone = stdio.0.lock().await.try_clone().await.map_err(wire_error)?;
-            self.reserve_stdio(1)?;
-            Ok(context.register(RetainedStdioSend(Mutex::new(clone))))
+            let clone = stdio
+                .stdio
+                .lock()
+                .await
+                .try_clone()
+                .await
+                .map_err(wire_error)?;
+            let slot = self.reserve_stdio()?;
+            Ok(context.register(RetainedStdioSend {
+                stdio: Mutex::new(clone),
+                _slot: slot,
+            }))
         }
         .await;
         ResponseKind::StdioSendClone(result)
@@ -1098,7 +1125,7 @@ impl Connection {
             }
         };
         let mut send = context.respond_with_trailer(ResponseKind::StdioRecvRead(Ok(())));
-        let mut stdio = stdio.0.lock().await;
+        let mut stdio = stdio.stdio.lock().await;
         let mut source = (&mut *stdio).take(len as u64);
         if io::copy(&mut source, &mut send).await.is_ok() {
             send.finish();
@@ -1112,9 +1139,18 @@ impl Connection {
     ) -> ResponseKind {
         let result = async {
             let stdio = self.retained_stdio_recv(context, stdio)?;
-            let clone = stdio.0.lock().await.try_clone().await.map_err(wire_error)?;
-            self.reserve_stdio(1)?;
-            Ok(context.register(RetainedStdioRecv(Mutex::new(clone))))
+            let clone = stdio
+                .stdio
+                .lock()
+                .await
+                .try_clone()
+                .await
+                .map_err(wire_error)?;
+            let slot = self.reserve_stdio()?;
+            Ok(context.register(RetainedStdioRecv {
+                stdio: Mutex::new(clone),
+                _slot: slot,
+            }))
         }
         .await;
         ResponseKind::StdioRecvClone(result)
@@ -1270,8 +1306,11 @@ impl Connection {
                 .to_stdio_send()
                 .await
                 .map_err(wire_error)?;
-            self.reserve_stdio(1)?;
-            Ok(context.register(RetainedStdioSend(Mutex::new(stdio))))
+            let slot = self.reserve_stdio()?;
+            Ok(context.register(RetainedStdioSend {
+                stdio: Mutex::new(stdio),
+                _slot: slot,
+            }))
         }
         .await;
         ResponseKind::FileToStdioSend(result)
@@ -1291,8 +1330,11 @@ impl Connection {
                 .to_stdio_recv()
                 .await
                 .map_err(wire_error)?;
-            self.reserve_stdio(1)?;
-            Ok(context.register(RetainedStdioRecv(Mutex::new(stdio))))
+            let slot = self.reserve_stdio()?;
+            Ok(context.register(RetainedStdioRecv {
+                stdio: Mutex::new(stdio),
+                _slot: slot,
+            }))
         }
         .await;
         ResponseKind::FileToStdioRecv(result)

--- a/dolang-vfs/tests/dolang_vfs/extension.rs
+++ b/dolang-vfs/tests/dolang_vfs/extension.rs
@@ -1,6 +1,8 @@
 #![cfg(unix)]
 
-use dolang_vfs::extension::{ExtContext, ExtOpaque, ExtResource, VfsExtension, vfs_extension};
+use dolang_vfs::extension::{
+    ExtCite, ExtContext, ExtGift, ExtResource, VfsExtension, vfs_extension,
+};
 use dolang_vfs::{AnyVfs, client::Client, direct::Direct};
 use serde::{Deserialize, Serialize};
 use tempfile::tempdir;
@@ -18,13 +20,13 @@ impl ExtResource for Counter {
 #[derive(Serialize, Deserialize)]
 enum CounterRequest {
     Open(i64),
-    Add(ExtOpaque<CounterMarker>, i64),
-    Close(ExtOpaque<CounterMarker>),
+    Add(ExtCite<CounterMarker>, i64),
+    Close(ExtCite<CounterMarker>),
 }
 
 #[derive(Serialize, Deserialize)]
 enum CounterResponse {
-    Handle(ExtOpaque<CounterMarker>),
+    Handle(ExtGift<CounterMarker>),
     Value(i64),
     Closed,
 }
@@ -65,7 +67,7 @@ impl VfsExtension for CounterExt {
 
 vfs_extension!(CounterExt);
 
-async fn open(vfs: &AnyVfs, initial: i64) -> ExtOpaque<CounterMarker> {
+async fn open(vfs: &AnyVfs, initial: i64) -> ExtGift<CounterMarker> {
     match vfs
         .call_extension::<CounterExt>(CounterRequest::Open(initial))
         .await
@@ -76,9 +78,9 @@ async fn open(vfs: &AnyVfs, initial: i64) -> ExtOpaque<CounterMarker> {
     }
 }
 
-async fn add(vfs: &AnyVfs, handle: ExtOpaque<CounterMarker>, delta: i64) -> i64 {
+async fn add(vfs: &AnyVfs, handle: &ExtGift<CounterMarker>, delta: i64) -> i64 {
     match vfs
-        .call_extension::<CounterExt>(CounterRequest::Add(handle, delta))
+        .call_extension::<CounterExt>(CounterRequest::Add(handle.cite(), delta))
         .await
         .unwrap()
     {
@@ -87,9 +89,9 @@ async fn add(vfs: &AnyVfs, handle: ExtOpaque<CounterMarker>, delta: i64) -> i64 
     }
 }
 
-async fn close(vfs: &AnyVfs, handle: ExtOpaque<CounterMarker>) {
+async fn close(vfs: &AnyVfs, handle: ExtGift<CounterMarker>) {
     match vfs
-        .call_extension::<CounterExt>(CounterRequest::Close(handle))
+        .call_extension::<CounterExt>(CounterRequest::Close(handle.cite()))
         .await
         .unwrap()
     {
@@ -100,8 +102,8 @@ async fn close(vfs: &AnyVfs, handle: ExtOpaque<CounterMarker>) {
 
 async fn exercise_counter(vfs: &AnyVfs) {
     let handle = open(vfs, 10).await;
-    assert_eq!(add(vfs, handle.clone(), 5).await, 15);
-    assert_eq!(add(vfs, handle.clone(), -3).await, 12);
+    assert_eq!(add(vfs, &handle, 5).await, 15);
+    assert_eq!(add(vfs, &handle, -3).await, 12);
     close(vfs, handle).await;
 }
 

--- a/test/proc/run.dol
+++ b/test/proc/run.dol
@@ -425,6 +425,17 @@ def cross_domain_pipeline_relays_between_two_remote_vfs()
   assert_eq $res foo
 
 #[test]
+def stopping_remote_vfs_after_abandoned_pipeline()
+  # Throwing from a later stage cancels the pipe request that set the pipeline
+  # up, so its response comes back with nobody left to claim the stdio
+  # endpoints it carries. Those endpoints hold drain slots, so if nothing
+  # releases them the `stop` in `with_remote_vfs` waits on the drain forever.
+  assert_throws $RuntimeError do
+    with_remote_vfs do pipeline
+      do run echo hi
+      do throw RuntimeError "abandoned"
+
+#[test]
 def cross_domain_redirects_host_file_into_remote_process_stdin()
   with_temp_dir do |dir|
     let path = (dir / "input.txt")


### PR DESCRIPTION
This fixes several oversights/problems, particularly with resources being leaked if an RPC response carrying a gifted handle is never processed due to call cancellation.  Opaque handles now distinguish gift/citation and are reference counted at the protocol level and by `Drop` to ensure deterministic, race-free cleanup.