### PR TITLE
dolang-rpc: await restored credits during graceful server shutdown

### DIFF
--- a/dolang-rpc/ARCHITECTURE.md
+++ b/dolang-rpc/ARCHITECTURE.md
@@ -865,10 +865,14 @@ closes, which means every handle that could still queue work is gone.
 *and* every dispatched call has answered. The send driver then finishes
 everything it holds, `has_pending` rather than `has_work`, parked sends
 included — the receive half is still running, so the credit that releases them
-can still arrive. The condition also requires the outgoing channel to be
-drained: a handler queues its response and *then* completes, and completing is
-what seals the drain, so at the instant the signal lands the last response may
-still be in the channel rather than in the scheduler.
+can still arrive. It then waits for all payload quota charged by those
+responses to return. A peer may have consumed the final response while its
+`PayloadCredit` control message is still queued; closing a pipe transport in
+that interval makes an intermediate relay's write fail. The condition also
+requires the outgoing channel to be drained: a handler queues its response and
+*then* completes, and completing is what seals the drain, so at the instant the
+signal lands the last response may still be in the channel rather than in the
+scheduler.
 
 `Abrupt` is published unconditionally on the receive driver's way out, and it
 sticks — it cannot be downgraded. No further credit can arrive, so the send

--- a/dolang-rpc/src/server.rs
+++ b/dolang-rpc/src/server.rs
@@ -800,7 +800,11 @@ impl<P: Protocol> SendDriver<P> {
                 // last response may still be sitting in the channel, not yet
                 // admitted to the scheduler, which would leave `has_pending`
                 // reporting nothing to do.
-                Drain::Graceful => !self.scheduler.has_pending() && self.outgoing.is_empty(),
+                Drain::Graceful => {
+                    !self.scheduler.has_pending()
+                        && self.outgoing.is_empty()
+                        && self.shared.payload_budget.is_restored()
+                }
                 Drain::Abrupt => !self.scheduler.has_work(),
             };
             if done {
@@ -818,6 +822,12 @@ impl<P: Protocol> SendDriver<P> {
                 // terminal condition is the whole of the arm — the loop head
                 // above does the work.
                 _ = self.drain.changed() => {}
+                // Once the response queue is empty, graceful shutdown still
+                // owes the peer time to return the payload credits for those
+                // responses. EOF changes the drain mode to `Abrupt` through
+                // the receive driver, so a departed peer cannot strand this.
+                _ = self.shared.payload_budget.wait_restored(),
+                    if mode == Drain::Graceful && !self.shared.payload_budget.is_restored() => {}
                 // Not raced against anything — see the matching comment in
                 // client.rs's writer loop. A dropped send future could leave a
                 // committed partial fragment on the transport, or — on

--- a/dolang-rpc/src/window.rs
+++ b/dolang-rpc/src/window.rs
@@ -24,7 +24,7 @@
 use std::{
     collections::HashMap,
     sync::{Arc, Mutex, MutexGuard},
-    task::Waker,
+    task::{Poll, Waker},
 };
 
 fn lock<T>(mutex: &Mutex<T>) -> MutexGuard<'_, T> {
@@ -204,6 +204,7 @@ pub(crate) struct PayloadBudget {
 
 struct PayloadBudgetState {
     available: usize,
+    capacity: usize,
     wakers: Vec<Waker>,
 }
 
@@ -212,6 +213,7 @@ impl PayloadBudget {
         Self {
             state: Mutex::new(PayloadBudgetState {
                 available,
+                capacity: available,
                 wakers: Vec::new(),
             }),
         }
@@ -220,6 +222,11 @@ impl PayloadBudget {
     #[cfg(test)]
     pub(crate) fn available(&self) -> usize {
         lock(&self.state).available
+    }
+
+    pub(crate) fn is_restored(&self) -> bool {
+        let state = lock(&self.state);
+        state.available == state.capacity
     }
 
     /// Takes `n` bytes if the whole amount is available, reporting whether it
@@ -265,6 +272,31 @@ impl PayloadBudget {
         if !state.wakers.iter().any(|parked| parked.will_wake(waker)) {
             state.wakers.push(waker.clone());
         }
+    }
+
+    /// Waits until every byte charged to the peer has been returned.
+    ///
+    /// A graceful server drain uses this after its last response has reached
+    /// the wire. The final payload credit is itself an outbound control
+    /// message at the peer, so closing the transport before it arrives can
+    /// race that write through an intermediate pipe relay.
+    pub(crate) async fn wait_restored(&self) {
+        std::future::poll_fn(|cx| {
+            let mut state = lock(&self.state);
+            if state.available == state.capacity {
+                Poll::Ready(())
+            } else {
+                if !state
+                    .wakers
+                    .iter()
+                    .any(|parked| parked.will_wake(cx.waker()))
+                {
+                    state.wakers.push(cx.waker().clone());
+                }
+                Poll::Pending
+            }
+        })
+        .await
     }
 }
 

--- a/dolang-rpc/tests/dolang_rpc/session.rs
+++ b/dolang-rpc/tests/dolang_rpc/session.rs
@@ -2243,6 +2243,38 @@ async fn graceful_shutdown_delivers_responses_blocked_on_payload_quota() {
 }
 
 #[tokio::test]
+async fn graceful_shutdown_waits_for_the_last_response_payload_credit() {
+    let (client_io, server_io) = tokio::io::duplex(8192);
+    let mut server = drain_server(server_io);
+    let client = drain_client(client_io).await;
+
+    let response = client.call(DrainRequest::Big);
+    let shutdown = client.call(DrainRequest::Shutdown);
+    let mut response = response.await.unwrap();
+    let credit = response.take_payload_credit();
+    assert_eq!(response.into_response().0.len(), BIG);
+    assert_eq!(
+        shutdown.await.unwrap().into_response(),
+        DrainResponse(Vec::new())
+    );
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(50), &mut server)
+            .await
+            .is_err(),
+        "server exited while the client's final payload credit was still held",
+    );
+
+    credit.release();
+    tokio::time::timeout(Duration::from_secs(5), &mut server)
+        .await
+        .expect("server did not finish after its payload credit returned")
+        .unwrap()
+        .unwrap();
+    client.close().await;
+}
+
+#[tokio::test]
 async fn a_lost_peer_does_not_hang_a_send_blocked_on_payload_quota() {
     // The mirror of the test above: with the receive half gone there is no
     // credit left to wait for, so the writer must abandon what it cannot

--- a/dolang-shell-vfs/tests/integration.rs
+++ b/dolang-shell-vfs/tests/integration.rs
@@ -920,18 +920,16 @@ mod login_env {
 /// disappearing at the right moment -- lives in the CLI, not the library.
 #[cfg(unix)]
 mod accept_mode {
-    use std::{
-        io::{BufRead, BufReader, Write},
-        os::unix::fs::PermissionsExt,
-        path::Path,
-        process::{Command, Stdio},
-        time::Duration,
-    };
+    use std::{os::unix::fs::PermissionsExt, path::Path, process::Stdio, time::Duration};
 
     use dolang_rpc::AuthKey;
     use dolang_vfs::client::Client;
     use tempfile::tempdir;
     use tokio::time::timeout;
+    use tokio::{
+        io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
+        process::{Child, Command},
+    };
 
     use super::AGENT_BIN;
 
@@ -948,7 +946,7 @@ mod accept_mode {
 
     /// Spawns the agent in `--accept --key-stdin` mode and returns once it has
     /// bound its socket and printed `READY`.
-    fn spawn_accept(socket_path: &Path, key: &[u8]) -> std::process::Child {
+    async fn spawn_accept(socket_path: &Path, key: &[u8]) -> Child {
         let mut child = Command::new(AGENT_BIN)
             .arg("--key-stdin")
             .arg("--accept")
@@ -963,19 +961,23 @@ mod accept_mode {
         let mut stdin = child.stdin.take().expect("stdin not captured");
         stdin
             .write_all(&[u8::try_from(key.len()).unwrap()])
+            .await
             .unwrap();
-        stdin.write_all(key).unwrap();
-        stdin.flush().unwrap();
+        stdin.write_all(key).await.unwrap();
+        stdin.flush().await.unwrap();
         drop(stdin);
 
-        wait_for_ready(&mut child).expect("agent did not become ready");
+        wait_for_ready(&mut child)
+            .await
+            .expect("agent did not become ready");
         child
     }
 
-    fn wait_for_ready(child: &mut std::process::Child) -> std::io::Result<()> {
+    async fn wait_for_ready(child: &mut Child) -> std::io::Result<()> {
         let stdout = child.stdout.take().expect("stdout not captured");
-        for line in BufReader::new(stdout).lines() {
-            if line.map_err(std::io::Error::other)? == "READY" {
+        let mut lines = BufReader::new(stdout).lines();
+        while let Some(line) = lines.next_line().await? {
+            if line == "READY" {
                 return Ok(());
             }
         }
@@ -983,6 +985,13 @@ mod accept_mode {
             std::io::ErrorKind::UnexpectedEof,
             "process exited before READY",
         ))
+    }
+
+    async fn wait_for_exit(child: &mut Child) -> std::process::ExitStatus {
+        timeout(Duration::from_secs(5), child.wait())
+            .await
+            .expect("timeout waiting for agent to exit")
+            .expect("wait")
     }
 
     async fn connect(socket_path: &Path, key: &[u8]) -> Result<Client, dolang_vfs::error::Error> {
@@ -997,7 +1006,7 @@ mod accept_mode {
     #[tokio::test]
     async fn accepts_one_authenticated_client_and_unlinks_the_socket() {
         let (_dir, socket_path) = find_free_socket_path();
-        let mut child = spawn_accept(&socket_path, TEST_KEY);
+        let mut child = spawn_accept(&socket_path, TEST_KEY).await;
 
         let client = connect(&socket_path, TEST_KEY).await.expect("connect");
 
@@ -1015,14 +1024,14 @@ mod accept_mode {
         );
 
         client.stop().await.expect("stop");
-        let status = child.wait().expect("wait");
+        let status = wait_for_exit(&mut child).await;
         assert!(status.success(), "agent exited with {status}");
     }
 
     #[tokio::test]
     async fn a_wrong_key_neither_consumes_the_slot_nor_unlinks_the_socket() {
         let (_dir, socket_path) = find_free_socket_path();
-        let mut child = spawn_accept(&socket_path, TEST_KEY);
+        let mut child = spawn_accept(&socket_path, TEST_KEY).await;
 
         let result = connect(&socket_path, b"an-entirely-different-key").await;
         assert!(result.is_err(), "a client with the wrong key was accepted");
@@ -1037,14 +1046,14 @@ mod accept_mode {
             .await
             .expect("the intended client should still be served");
         client.stop().await.expect("stop");
-        let status = child.wait().expect("wait");
+        let status = wait_for_exit(&mut child).await;
         assert!(status.success(), "agent exited with {status}");
     }
 
     #[tokio::test]
     async fn a_silent_connection_does_not_block_the_intended_client() {
         let (_dir, socket_path) = find_free_socket_path();
-        let mut child = spawn_accept(&socket_path, TEST_KEY);
+        let mut child = spawn_accept(&socket_path, TEST_KEY).await;
 
         // Connect and then say nothing at all, which is what a peer trying to
         // wedge the accept loop would do.
@@ -1054,7 +1063,7 @@ mod accept_mode {
             .await
             .expect("a stalled peer must not block the accept loop");
         client.stop().await.expect("stop");
-        let status = child.wait().expect("wait");
+        let status = wait_for_exit(&mut child).await;
         assert!(status.success(), "agent exited with {status}");
     }
 
@@ -1064,6 +1073,7 @@ mod accept_mode {
             .arg("--key-stdin")
             .arg("--stdio")
             .output()
+            .await
             .expect("failed to spawn agent");
         assert!(!output.status.success());
         let stderr = String::from_utf8_lossy(&output.stderr);

--- a/dolang-shell/tests/windows_vfs.rs
+++ b/dolang-shell/tests/windows_vfs.rs
@@ -49,7 +49,11 @@ async fn embedded_vfs_mode_serves_and_stops() {
     assert!(metadata.len > 0);
 
     client.stop().await.unwrap();
-    assert!(child.wait().unwrap().success());
+    let status = tokio::task::spawn_blocking(move || child.wait())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(status.success());
 }
 
 #[tokio::test]


### PR DESCRIPTION
This ensures we do not cause an upstream stdio relay (e.g. ssh, docker) to receive SIGPIPE/EPIPE because of a credit control message from the client.