### PR TITLE
Fix miri error

### DIFF
--- a/dodo.dol
+++ b/dodo.dol
@@ -238,7 +238,7 @@ return $
       collect: true
     do |args|
       env MIRIFLAGS: -Zmiri-disable-isolation do
-        dodo.show cargo +nightly miri test
+        run_cargo +nightly miri test
           for crate = MIRI_CRATES
             -p $crate
           ...args.args

--- a/dolang-runtime/src/object/native.rs
+++ b/dolang-runtime/src/object/native.rs
@@ -611,7 +611,7 @@ impl<'v, 'a, T: Object<'v>> Instance<'v, 'a, T> {
     /// — e.g. [`Object::eq`], [`Object::band`]) obtain its own type in order
     /// to [`Type::cast`] another value into the same type, or construct a
     /// new instance of it.
-    pub fn ty(&self, vm: &'v Vm<'v>) -> Type<'v, T> {
+    pub fn ty(&self, vm: &Vm<'v>) -> Type<'v, T> {
         // SAFETY: `self.receiver` is a live `ObjectWrap<'v,T>` receiver.
         let vtbl = unsafe {
             self.receiver
@@ -2244,10 +2244,14 @@ pub struct Type<'v, T: Object<'v>> {
     pub(crate) type_vtbl: TypeHandle<'v, TypeObjectWrap<'v, T>>,
     /// Index into `Vm::type_singletons` for `Input` and `op_type` dispatch.
     pub(crate) singleton_idx: usize,
-    /// The VM this type belongs to, so that [`Type::cast`] can reach
-    /// [`BuiltinTypes::class_instance`](crate::object::BuiltinTypes) to look through the
-    /// native slots of a Do subclass.
-    pub(crate) vm: &'v Vm<'v>,
+    /// Handle for [`ClassInstance`](super::class::ClassInstance), so that [`Type::cast`] can
+    /// look through the native slots of a Do subclass.
+    ///
+    /// A handle rather than a `&Vm` deliberately: it is a plain vtable pointer, so it needs
+    /// no VM borrow to carry around (which would be unsound to mint from `&mut Builder` at
+    /// registration time) and stays usable where no [`Vm`] reference exists at all, such as
+    /// [`Object::finalize`].
+    pub(crate) class_instance: TypeHandle<'v, super::class::ClassInstance<'v>>,
 }
 
 impl<'v, T: Object<'v>> Copy for Type<'v, T> {}
@@ -2329,7 +2333,7 @@ impl<'v, T: Object<'v>> Type<'v, T> {
             });
         }
         value
-            .downcast_native(self.vm, self.vtbl)
+            .downcast_native_with(self.class_instance, self.vtbl)
             .map(|receiver| Cast {
                 receiver,
                 delegator: Some(value),
@@ -2341,13 +2345,13 @@ impl<'v, T: Object<'v>> Type<'v, T> {
     /// # Safety
     /// `header` must point to a GC-allocated `TypeObjectWrap<'v,T>` whose vtable is
     /// `TypeVtbl<'v>`.
-    pub(crate) unsafe fn from_type_header(header: NonNull<arena::Header>, vm: &'v Vm<'v>) -> Self {
+    pub(crate) unsafe fn from_type_header(header: NonNull<arena::Header>, vm: &Vm<'v>) -> Self {
         let vtbl = unsafe { header.as_ref().vtbl().cast::<TypeVtbl<'v>>() };
         Type {
             vtbl: unsafe { TypeHandle::new(vtbl.as_ref().inst_vtbl.cast()) },
             type_vtbl: unsafe { TypeHandle::new(vtbl.cast()) },
             singleton_idx: unsafe { vtbl.as_ref().inst_vtbl.as_ref().singleton_idx },
-            vm,
+            class_instance: vm.builtin_types().class_instance,
         }
     }
 
@@ -3000,7 +3004,7 @@ impl<'v, 'a, T: Object<'v>> TypeBuilder<'v, 'a, T> {
             vtbl: unsafe { TypeHandle::new(result.inst_vtbl.cast()) },
             type_vtbl: unsafe { TypeHandle::new(result.type_vtbl.cast()) },
             singleton_idx: result.singleton_idx,
-            vm: result.vm.vm_ref(),
+            class_instance: result.vm.inner.builtin_types().class_instance,
         };
 
         let singleton = Value::from_object(protocol::GcObj::new_annex(
@@ -3182,7 +3186,7 @@ impl<'v, 'a, T: Object<'v>> Recv<'v, 'a, TypeObjectWrap<'v, T>> {
         &vm.type_singletons[self.inst_vtbl().singleton_idx]
     }
 
-    fn ty(&self, vm: &'v Vm<'v>) -> Type<'v, T> {
+    fn ty(&self, vm: &Vm<'v>) -> Type<'v, T> {
         // SAFETY: `self` is a live `TypeObjectWrap<'v, T>` receiver.
         unsafe { Type::<T>::from_type_header(self.as_header().cast(), vm) }
     }

--- a/dolang-runtime/src/value/mod.rs
+++ b/dolang-runtime/src/value/mod.rs
@@ -22,7 +22,7 @@ use crate::{
     method,
     object::{
         self, BoundMethod, array, backtrace,
-        class::iter_natives,
+        class::{self, iter_natives},
         dict,
         function::Function,
         protocol::{Dispatch, GcObj, Header, Inspect, Protocol, Spread, SpreadContext, TypeHandle},
@@ -426,10 +426,24 @@ impl<'v> Value<'v> {
         vm: &Vm<'v>,
         vtbl: TypeHandle<'v, T>,
     ) -> Option<gc::Borrow<'v, 'a, Header, T>> {
+        self.downcast_native_with(vm.builtin_types().class_instance, vtbl)
+    }
+
+    /// [`Value::downcast_native`] against a pre-obtained [`ClassInstance`] type handle.
+    ///
+    /// Handles are plain vtable pointers, so a caller that has one cached (such as
+    /// [`Type`](crate::object::Type)) can look through subclass slots without holding a
+    /// [`Vm`] reference — which matters in contexts where none exists, such as
+    /// [`Object::finalize`](crate::object::Object::finalize).
+    pub(crate) fn downcast_native_with<'a, T: ?Sized + Protocol<'v>>(
+        &'a self,
+        class_instance: TypeHandle<'v, class::ClassInstance<'v>>,
+        vtbl: TypeHandle<'v, T>,
+    ) -> Option<gc::Borrow<'v, 'a, Header, T>> {
         if let Some(borrow) = self.downcast_ref(vtbl) {
             return Some(borrow);
         }
-        let ci_borrow = self.downcast_ref(vm.builtin_types().class_instance)?;
+        let ci_borrow = self.downcast_ref(class_instance)?;
         for slot_val in iter_natives(ci_borrow) {
             if let Some(borrow) = slot_val.downcast_ref(vtbl) {
                 return Some(borrow);

--- a/dolang-runtime/src/vm.rs
+++ b/dolang-runtime/src/vm.rs
@@ -802,16 +802,6 @@ impl Builder<'static> {
 }
 
 impl<'v> Builder<'v> {
-    /// A `'v`-lifetime reference to the VM under construction, for storing in handles that
-    /// outlive registration (such as [`Type`](crate::object::Type)).
-    ///
-    /// Safety rationale is the same promise [`Builder::enter`] relies on: [`Builder::build`]
-    /// constructs the `Builder` in place and thereafter only lends it out as `&mut`, so the
-    /// `Vm` it owns is never moved and is not dropped until every `'v` lifetime has ended.
-    pub(crate) fn vm_ref(&self) -> &'v Vm<'v> {
-        unsafe { mem::transmute::<&Vm<'v>, &'v Vm<'v>>(&self.inner) }
-    }
-
     /// Resolve a name to a symbol. The returned symbol will live for the life of the VM.
     #[inline(never)]
     pub fn sym(&mut self, name: &str) -> Sym<'v, 'v> {


### PR DESCRIPTION
The VM can't be lifetime transmuted while the builder is still outstanding as this violates aliasing rules.  Store precisely the needed (already address-stable, immutable) object that's needed in `Type` instead.