### PR TITLE
Zip write improvements:

### DIFF
--- a/docs/api/zip/archive.md
+++ b/docs/api/zip/archive.md
@@ -34,7 +34,7 @@ afterward rather than erroring, since `len` cannot itself raise an error.
 
 ## Methods
 
-### `open name :mode? func?`
+### `open name :mode? :size? :compression? func?`
 
 Opens a file within the archive. Always creates a regular file entry in
 write mode — use [`create_dir`](#create_dir-name-mode) or
@@ -43,16 +43,30 @@ which carry no content and so have no use for a write handle.
 
 #### Parameters
 
-| Name   | Type                    | Description                                          |
-| ------ | ----------------------- | ---------------------------------------------------- |
-| `name` | [`Str`](../std/str.md)  | Name/path of the file within the archive             |
-| `mode` | [`Int`](../std/int.md)? | Unix permission bits in write mode (default: `0`)    |
-| `func` | func                    | Callable to run with the file; auto-closes when done |
+| Name          | Type                    | Description                                          |
+| ------------- | ----------------------- | ---------------------------------------------------- |
+| `name`        | [`Str`](../std/str.md)  | Name/path of the file within the archive             |
+| `mode`        | [`Int`](../std/int.md)? | Unix permission bits in write mode (default: `0`)    |
+| `size`        | [`Int`](../std/int.md)? | Expected uncompressed size — see below               |
+| `compression` | [`Sym`](../std/sym.md)? | `:STORED:`, `:DEFLATE:` (default), or `:ZSTD:`       |
+| `func`        | func                    | Callable to run with the file; auto-closes when done |
+
+`mode`, `size`, and `compression` apply to entries being created; passing
+any of them in read mode is an error.
 
 ##### Mode-specific behavior
 
 - **Read mode:** Opens an existing file for reading
 - **Write mode:** Creates a new file entry for writing
+
+##### `size` and entries over 4 GiB
+
+The writer reserves space for an entry's ZIP64 size fields in its local file
+header before any data is written, and patches the real sizes in afterward. A
+field that was not reserved cannot appear later, so an entry that turns out to
+exceed 4 GiB fails when it is closed unless `size` announced it up front. Pass
+the uncompressed size whenever it is known; it is a hint, and the actual sizes
+are what end up recorded.
 
 #### Returns
 
@@ -72,6 +86,14 @@ open "archive.zip" do |archive|
 open "output.zip" "w" do |archive|
   archive.open "data.txt" mode: 0o644 do |file|
     file.write "Hello, World!"
+
+# Store an already-compressed payload without deflating it again
+open "bundle.zip" "w" do |archive|
+  let total = payload.metadata().size
+  archive.open "disk.qcow2" compression: :STORED: size: $total do |file|
+    payload.open rb do |source|
+      for chunk = source
+        file.write $chunk
 ```
 
 ### `create_dir name :mode?`

--- a/docs/api/zip/file.md
+++ b/docs/api/zip/file.md
@@ -1,7 +1,7 @@
 # File
 
 File objects are returned by
-[`Archive.open()`](./archive.md#open-name-mode-func) and
+[`Archive.open()`](./archive.md#open-name-mode-size-compression-func) and
 [`Entry.open()`](./entry.md#open-block) and provide methods for reading from
 or writing to files within a ZIP archive. Entry metadata such as size and
 Unix mode is available on [`Entry`](./entry.md) rather than `File`.

--- a/dolang-ext-zip/src/zip.rs
+++ b/dolang-ext-zip/src/zip.rs
@@ -117,6 +117,45 @@ fn parse_mode_bits<'v, 's>(
         .ok_or_else(|| Error::value(strand, "mode: expected permission bits in range 0..=0o7777"))
 }
 
+/// Parses an entry's expected uncompressed size, which reserves the ZIP64 size
+/// fields in the local file header when it crosses the legacy 4 GiB limit.
+fn parse_size<'v, 's>(
+    strand: &mut Strand<'v, 's>,
+    size: Option<Slot<'v, '_>>,
+) -> Result<'v, 's, Option<u64>> {
+    let Some(size) = size else {
+        return Ok(None);
+    };
+    let size = size
+        .to_i64(strand)
+        .map_err(|_| Error::type_error(strand, "size: expected non-negative Int"))?;
+    u64::try_from(size)
+        .map(Some)
+        .map_err(|_| Error::value(strand, "size: expected non-negative Int"))
+}
+
+/// Parses an entry's compression method, defaulting to `Deflate`.
+fn parse_compression<'v, 's>(
+    strand: &mut Strand<'v, 's>,
+    compression: Option<Slot<'v, '_>>,
+    stored: Sym<'v, 'v>,
+    deflate: Sym<'v, 'v>,
+    zstd: Sym<'v, 'v>,
+) -> Result<'v, 's, Compression> {
+    let Some(compression) = compression else {
+        return Ok(Compression::Deflate);
+    };
+    match compression.as_sym(strand) {
+        Some(sym) if sym == stored => Ok(Compression::Stored),
+        Some(sym) if sym == deflate => Ok(Compression::Deflate),
+        Some(sym) if sym == zstd => Ok(Compression::Zstd),
+        _ => Err(Error::value(
+            strand,
+            "compression: expected :STORED:, :DEFLATE:, or :ZSTD:",
+        )),
+    }
+}
+
 /// Opens the entry at `index` for reading. Shared by `Archive::open` (after
 /// resolving a name to an index via linear scan) and `Entry::open` (which
 /// already knows its index).
@@ -204,6 +243,11 @@ impl<'v> Object<'v> for Archive {
     fn build<'a>(mut builder: TypeBuilder<'v, 'a, Self>) -> TypeBuilder<'v, 'a, Self> {
         let close = builder.sym("close");
         let mode_sym = builder.sym("mode");
+        let size_sym = builder.sym("size");
+        let compression_sym = builder.sym("compression");
+        let stored = builder.sym("STORED");
+        let deflate = builder.sym("DEFLATE");
+        let zstd = builder.sym("ZSTD");
         builder
             .get("entries", |this, strand, out| {
                 let annex = this.annex();
@@ -222,7 +266,15 @@ impl<'v> Object<'v> for Archive {
                 async move |this, strand, args, out, [mut file, mut tmp]| {
                     let annex = this.annex();
                     let global = annex.global;
-                    let ([name], [block, mode]) = unpack!(strand, args, 1, 1, mode_sym = None)?;
+                    let ([name], [block, mode, size, compression]) = unpack!(
+                        strand,
+                        args,
+                        1,
+                        1,
+                        mode_sym = None,
+                        size_sym = None,
+                        compression_sym = None
+                    )?;
                     let name = name.to_string(strand)?;
 
                     if annex.is_file_open() {
@@ -238,11 +290,20 @@ impl<'v> Object<'v> for Archive {
                         };
                         match inner {
                             ArchiveInner::Read(archive) => {
-                                if mode.is_some() {
-                                    return Err(Error::type_error(
-                                        strand,
-                                        "mode is only valid when creating entries in write mode",
-                                    ));
+                                for (option, given) in [
+                                    ("mode", mode.is_some()),
+                                    ("size", size.is_some()),
+                                    ("compression", compression.is_some()),
+                                ] {
+                                    if given {
+                                        return Err(Error::type_error(
+                                            strand,
+                                            format!(
+                                                "{option} is only valid when creating entries in \
+                                                 write mode"
+                                            ),
+                                        ));
+                                    }
                                 }
                                 let mut index = None;
                                 for (i, entry) in archive.file().entries().iter().enumerate() {
@@ -258,8 +319,18 @@ impl<'v> Object<'v> for Archive {
                             }
                             ArchiveInner::Write(writer) => {
                                 let mode_bits = parse_mode_bits(strand, mode)?;
-                                let mut entry =
-                                    ZipEntryBuilder::new(name.into(), Compression::Deflate);
+                                let size = parse_size(strand, size)?;
+                                let compression =
+                                    parse_compression(strand, compression, stored, deflate, zstd)?;
+                                let mut entry = ZipEntryBuilder::new(name.into(), compression);
+                                // Reserving the ZIP64 size fields up front is what
+                                // makes an entry larger than 4 GiB writable at all:
+                                // the seekable writer patches the header in place on
+                                // close, so a slot that was not reserved cannot
+                                // appear later.
+                                if let Some(size) = size {
+                                    entry = entry.size(size, size);
+                                }
                                 entry = entry.unix_permissions(FILE_TYPE | mode_bits);
                                 let entry =
                                     writer.write_entry_seekable(entry).await.into_do(strand)?;

--- a/dolang-shell-modules/lib/transfer.dol
+++ b/dolang-shell-modules/lib/transfer.dol
@@ -498,7 +498,9 @@ def pack_zip source destination prefix metadata indicator
         archive.symlink (str target) (str name) mode: $values[:mode:]
       else if (file_metadata.type == :FILE:)
         let values = (filesystem_metadata path :FILE: metadata)
-        archive.open (str name) mode: $values[:mode:] do |entry|
+        # The size hint reserves the ZIP64 fields in the local file header,
+        # without which an entry over 4 GiB cannot be written at all.
+        archive.open (str name) mode: $values[:mode:] size: $file_metadata.size do |entry|
           path.open rb do |file|
             for chunk = file
               entry.write $chunk

--- a/test/zip.dol
+++ b/test/zip.dol
@@ -7,6 +7,8 @@ import zip
     - test
   std:
     - ConcurrencyError
+    - TypeError
+    - ValueError
 
 #[test]
 #[vfs]
@@ -77,3 +79,64 @@ def nested_file_is_rejected()
         entries[1].open do |_| nil
       assert_throws $ConcurrencyError do
         archive.open (str entries[1].name) do |_| nil
+
+#[test]
+#[vfs]
+def stored_compression()
+  zip.open "stored.zip" "w" do |archive|
+    archive.open "stored.txt" compression: :STORED: do |file|
+      file.write "Hello, World!"
+    archive.open "deflated.txt" compression: :DEFLATE: do |file|
+      file.write "Hello, World!"
+    archive.open "default.txt" do |file|
+      file.write "Hello, World!"
+
+  zip.open "stored.zip" do |archive|
+    let entries = [...archive.entries]
+    assert_eq $entries[0].compression :STORED:
+    assert_eq $entries[0].compressed_size 13
+    assert_eq $entries[1].compression :DEFLATE:
+    assert_eq $entries[2].compression :DEFLATE:
+    for entry = entries
+      entry.open do |file|
+        assert_eq (str (file.read 1024)) "Hello, World!"
+
+#[test]
+#[vfs]
+def invalid_compression_is_rejected()
+  zip.open "invalid.zip" "w" do |archive|
+    assert_throws $ValueError do
+      archive.open "bogus.txt" compression: :BOGUS: do |_| nil
+
+# `size:` reserves the ZIP64 size fields in the local file header. Without the
+# reservation an entry over 4 GiB cannot be written at all, since the seekable
+# writer patches the header in place on close and cannot grow it. Passing a
+# reserving hint for a tiny entry exercises that path — reserve, then patch
+# back a size that fits — without writing 4 GiB.
+#[test]
+#[vfs]
+def zip64_size_hint()
+  let hint = (5 * 1024 * 1024 * 1024)
+  zip.open "zip64.zip" "w" do |archive|
+    archive.open "big.bin" compression: :STORED: size: $hint do |file|
+      file.write "Hello, World!"
+
+  zip.open "zip64.zip" do |archive|
+    let entries = [...archive.entries]
+    assert_eq $entries.len 1
+    assert_eq $entries[0].size 13
+    entries[0].open do |file|
+      assert_eq (str (file.read 1024)) "Hello, World!"
+
+#[test]
+#[vfs]
+def write_options_are_rejected_in_read_mode()
+  zip.open "options.zip" "w" do |archive|
+    archive.open "hello.txt" do |file|
+      file.write "Hello, World!"
+
+  zip.open "options.zip" do |archive|
+    assert_throws $TypeError do
+      archive.open "hello.txt" size: 13 do |_| nil
+    assert_throws $TypeError do
+      archive.open "hello.txt" compression: :STORED: do |_| nil


### PR DESCRIPTION
- Accept file size up front to turn on ZIP64
- Allow specifying per-file compression algorithm